### PR TITLE
Codegen: Use `sar` instead of `shr`

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -601,7 +601,7 @@ Error codegen_expression_x86_64_mswin
       fprintf(code,
               "push %%rcx\n"
               "mov %s, %%rcx\n"
-              "shr %%cl, %s\n"
+              "sar %%cl, %s\n"
               "pop %%rcx\n",
               register_name(r, expression->children->next_child->result_register),
               register_name(r, expression->children->result_register));


### PR DESCRIPTION
This replaces `shr` with `sar` since only the latter handles negative integers correctly:
```asm
shr $-64, $3 ; = 2305843009213693944 (0x1ffffffffffffff8)
sar $-64, $3 ; = -8                  (0xfffffffffffffff8)
```

At least this is what C compilers do. Signed `>>` in C is implementation-defined, but all major C compilers (gcc, clang, msvc) use `sar` when right-shifting an `int`.

This problem does not exist with left shifts since `shl` and `sal` are completely identical; they even have the same opcodes.