### PR TITLE
Registers

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -9,92 +9,90 @@
 #include <stdlib.h>
 #include <string.h>
 
-CodegenContext *codegen_context_create(CodegenContext *parent) {
+enum RegX86_64_MsWin : RegisterDescriptor {
+  REG_X86_64_MSWIN_RAX = 0,
+  REG_X86_64_MSWIN_R10 = 1,
+  REG_X86_64_MSWIN_R11 = 2,
+  REG_X86_64_MSWIN_RBX = 3,
+  REG_X86_64_MSWIN_RDI = 4,
+  REG_X86_64_MSWIN_RSI = 5,
+
+  REG_X86_64_MSWIN_COUNT = REG_X86_64_MSWIN_RSI + 1
+};
+
+#define INIT_REGISTER(desc, reg_name) \
+  registers[desc] = (Register){.name = reg_name, .in_use = 0, .descriptor = desc}
+
+/// Creates a context for the CG_FMT_x86_64_MSWIN architecture.
+CodegenContext *codegen_context_create_x86_64_mswin(CodegenContext *parent) {
+  Register *registers = calloc(REG_X86_64_MSWIN_COUNT, sizeof *registers);
+  INIT_REGISTER(REG_X86_64_MSWIN_RAX, "%rax");
+  INIT_REGISTER(REG_X86_64_MSWIN_R10, "%r10");
+  INIT_REGISTER(REG_X86_64_MSWIN_R11, "%r11");
+  INIT_REGISTER(REG_X86_64_MSWIN_RBX, "%rbx");
+  INIT_REGISTER(REG_X86_64_MSWIN_RDI, "%rdi");
+  INIT_REGISTER(REG_X86_64_MSWIN_RSI, "%rsi");
+
+  RegisterPool register_pool = {
+    .regs = registers,
+    .num_regs = REG_X86_64_MSWIN_COUNT,
+  };
+
   CodegenContext *cg_ctx = calloc(1,sizeof(CodegenContext));
   cg_ctx->parent = parent;
+  cg_ctx->registers = register_pool;
   cg_ctx->locals = environment_create(NULL);
-  // TODO/FIXME: This is specific to x86_64 right now [2022-08-18 Thu 10:40]
   cg_ctx->locals_offset = -32;
   return cg_ctx;
 }
 
+#undef INIT_REGISTER
+
 //================================================================ BEG REGISTER STUFF
 
-void print_registers(Register *base) {
-  Register *it = base;
-  while (it) {
-    printf("%s:%i\n", it->name, it->in_use);
-    it = it->next;
+void print_registers(CodegenContext *cg_ctx) {
+  for (RegisterDescriptor d = 0; d < cg_ctx->registers.num_regs; ++d) {
+    Register *reg = &cg_ctx->registers.regs[d];
+    printf("%s:%i\n", reg->name, reg->in_use);
   }
 }
 
-Register *register_create(char *name) {
-  Register *r = calloc(1,sizeof(Register));
-  assert(r && "Could not allocate memory for new register");
-  r->name = name;
-  return r;
+char register_descriptor_is_valid(CodegenContext *cg_ctx, RegisterDescriptor descriptor) {
+  return descriptor >= 0 && descriptor < cg_ctx->registers.num_regs;
 }
 
-void register_add(Register *base, char *name) {
-  while (base->next) { base = base->next; }
-  base->next = register_create(name);
-}
+RegisterDescriptor register_allocate(CodegenContext *cg_ctx) {
+  assert(cg_ctx->registers.num_regs > 0 && "Register pool is empty");
 
-// TODO: This is broken :^)
-void register_free(Register *base) {
-  Register *to_free = NULL;
-  while (base) {
-    to_free = base;
-    if (base->name) {
-      free(base->name);
+  for (RegisterDescriptor d = 0; d < cg_ctx->registers.num_regs; ++d) {
+    Register *reg = &cg_ctx->registers.regs[d];
+    if (reg->in_use == 0) {
+      reg->in_use = 1;
+      return reg->descriptor;
     }
-    base = base->next;
-    free(to_free);
   }
-}
 
-RegisterDescriptor register_allocate(Register *base) {
-  RegisterDescriptor register_descriptor = 0;
-  while (base) {
-    if (base->in_use == 0) {
-      base->in_use = 1;
-      return register_descriptor;
-    }
-    base = base->next;
-    register_descriptor++;
-  }
   printf("ERROR::register_allocate(): Could not allocate register!\n");
   exit(1);
-  return -1;
 }
 
 void register_deallocate
-(Register *base, RegisterDescriptor register_descriptor) {
-  while (base) {
-    if (register_descriptor == 0) {
-      base->in_use = 0;
-      return;
-    }
-    base = base->next;
-    register_descriptor--;
+(CodegenContext *cg_ctx, RegisterDescriptor descriptor) {
+  if (!register_descriptor_is_valid(cg_ctx, descriptor)) {
+    printf("ERROR::register_deallocate(): Invalid register descriptor!\n");
+    exit(1);
+  } else {
+    cg_ctx->registers.regs[descriptor].in_use = 0;
   }
-  printf("ERROR::register_deallocate(): Could not deallocate register %d\n",
-         register_descriptor);
-  exit(1);
 }
 
-char *register_name
-(Register *base, RegisterDescriptor register_descriptor) {
-  while (base) {
-    if (register_descriptor <= 0) {
-      return base->name;
-    }
-    base = base->next;
-    register_descriptor--;
+const char *register_name
+(CodegenContext *cg_ctx, RegisterDescriptor descriptor) {
+  if (!register_descriptor_is_valid(cg_ctx, descriptor)) {
+    printf("ERROR::register_name(): Could not find register with descriptor of %d\n",
+           descriptor);
   }
-  printf("ERROR::register_name(): Could not find register with descriptor of %d\n",
-         register_descriptor);
-  return NULL;
+  return cg_ctx->registers.regs[descriptor].name;
 }
 
 //================================================================ END REGISTER STUFF
@@ -169,8 +167,7 @@ char *symbol_to_address(CodegenContext *cg_ctx, Node *symbol) {
 
 // Forward declare codegen_function for codegen_expression
 Error codegen_function_x86_64_att_asm_mswin
-(Register *r,
- CodegenContext *cg_context,
+(CodegenContext *cg_context,
  ParsingContext *context,
  ParsingContext **next_child_context,
  char *name,
@@ -179,7 +176,6 @@ Error codegen_function_x86_64_att_asm_mswin
 
 Error codegen_expression_x86_64_mswin
 (FILE *code,
- Register *r,
  CodegenContext *cg_context,
  ParsingContext *context,
  ParsingContext **next_child_context,
@@ -203,10 +199,10 @@ Error codegen_expression_x86_64_mswin
     if (codegen_verbose) {
       fprintf(code, ";;#; INTEGER: %lld\n", expression->value.integer);
     }
-    expression->result_register = register_allocate(r);
+    expression->result_register = register_allocate(cg_context);
     fprintf(code, "mov $%lld, %s\n",
             expression->value.integer,
-            register_name(r, expression->result_register));
+            register_name(cg_context, expression->result_register));
     break;
   case NODE_TYPE_FUNCTION_CALL:
     if (codegen_verbose) {
@@ -222,28 +218,28 @@ Error codegen_expression_x86_64_mswin
     iterator = expression->children->next_child->children;
     while (iterator) {
       err = codegen_expression_x86_64_mswin
-        (code, r, cg_context, context, next_child_context, iterator);
+        (code, cg_context, context, next_child_context, iterator);
       if (err.type) { return err; }
-      fprintf(code, "pushq %s\n", register_name(r, iterator->result_register));
-      register_deallocate(r, iterator->result_register);
+      fprintf(code, "pushq %s\n", register_name(cg_context, iterator->result_register));
+      register_deallocate(cg_context, iterator->result_register);
       iterator = iterator->next_child;
       count++;
     }
 
-    err = codegen_expression_x86_64_mswin(code, r, cg_context, context, next_child_context, expression->children);
+    err = codegen_expression_x86_64_mswin(code, cg_context, context, next_child_context, expression->children);
     if (err.type) { return err; }
 
     // Emit call
-    fprintf(code, "call *%s\n", register_name(r, expression->children->result_register));
-    register_deallocate(r, expression->children->result_register);
+    fprintf(code, "call *%s\n", register_name(cg_context, expression->children->result_register));
+    register_deallocate(cg_context, expression->children->result_register);
     if (count) {
       fprintf(code, "add $%lld, %%rsp\n", count * 8);
     }
 
     // Copy return value of function call from RAX to result register
-    expression->result_register = register_allocate(r);
-    if (strcmp(register_name(r, expression->result_register), "%rax") != 0) {
-      fprintf(code, "mov %%rax, %s\n", register_name(r, expression->result_register));
+    expression->result_register = register_allocate(cg_context);
+    if (strcmp(register_name(cg_context, expression->result_register), "%rax") != 0) {
+      fprintf(code, "mov %%rax, %s\n", register_name(cg_context, expression->result_register));
       // Save overwritten in-use registers.
       fprintf(code, "pop %%rax\n");
     } else {
@@ -270,21 +266,21 @@ Error codegen_expression_x86_64_mswin
       // FIXME: Completely memory leaked here, no chance of freeing!
       result = label_generate();
     }
-    err = codegen_function_x86_64_att_asm_mswin(r, cg_context,
+    err = codegen_function_x86_64_att_asm_mswin(cg_context,
                                                 context, next_child_context,
                                                 result, expression, code);
 
     // Function returns beginning of instructions address.
-    expression->result_register = register_allocate(r);
+    expression->result_register = register_allocate(cg_context);
     fprintf(code, "lea %s(%%rip), %s\n",
             result,
-            register_name(r, expression->result_register));
+            register_name(cg_context, expression->result_register));
     break;
   case NODE_TYPE_DEREFERENCE:
     if (codegen_verbose) {
       fprintf(code, ";;#; Dereference\n");
     }
-    err = codegen_expression_x86_64_mswin(code, r, cg_context,
+    err = codegen_expression_x86_64_mswin(code, cg_context,
                                           context, next_child_context,
                                           expression->children);
     if (err.type) { return err; }
@@ -294,10 +290,10 @@ Error codegen_expression_x86_64_mswin
     if (codegen_verbose) {
       fprintf(code, ";;#; Addressof\n");
     }
-    expression->result_register = register_allocate(r);
+    expression->result_register = register_allocate(cg_context);
     fprintf(code, "lea %s, %s\n",
             symbol_to_address(cg_context, expression->children),
-            register_name(r, expression->result_register));
+            register_name(cg_context, expression->result_register));
     if (err.type) { return err; }
     break;
   case NODE_TYPE_IF:
@@ -306,7 +302,7 @@ Error codegen_expression_x86_64_mswin
     }
 
     // Generate if condition expression code.
-    err = codegen_expression_x86_64_mswin(code, r, cg_context,
+    err = codegen_expression_x86_64_mswin(code, cg_context,
                                           context, next_child_context,
                                           expression->children);
     if (err.type) { return err; }
@@ -318,10 +314,10 @@ Error codegen_expression_x86_64_mswin
     // Generate code using result register from condition expression.
     char *otherwise_label = label_generate();
     char *after_otherwise_label = label_generate();
-    char *condition_register_name = register_name(r, expression->children->result_register);
+    const char *condition_register_name = register_name(cg_context, expression->children->result_register);
     fprintf(code, "test %s, %s\n", condition_register_name, condition_register_name);
     fprintf(code, "jz %s\n", otherwise_label);
-    register_deallocate(r,expression->children->result_register);
+    register_deallocate(cg_context, expression->children->result_register);
 
     if (codegen_verbose) {
       fprintf(code, ";;#; If THEN\n");
@@ -344,23 +340,23 @@ Error codegen_expression_x86_64_mswin
     Node *last_expr = NULL;
     Node *expr = expression->children->next_child->children;
     while (expr) {
-      err = codegen_expression_x86_64_mswin(code, r, cg_context,
+      err = codegen_expression_x86_64_mswin(code, cg_context,
                                             ctx, &next_child_ctx,
                                             expr);
       if (err.type) { return err; }
       if (last_expr) {
-        register_deallocate(r, last_expr->result_register);
+        register_deallocate(cg_context, last_expr->result_register);
       }
       last_expr = expr;
       expr = expr->next_child;
     }
 
     // Generate code to copy last expr result register to if result register.
-    expression->result_register = register_allocate(r);
+    expression->result_register = register_allocate(cg_context);
     fprintf(code, "mov %s, %s\n",
-            register_name(r, last_expr->result_register),
-            register_name(r, expression->result_register));
-    register_deallocate(r, last_expr->result_register);
+            register_name(cg_context, last_expr->result_register),
+            register_name(cg_context, expression->result_register));
+    register_deallocate(cg_context, last_expr->result_register);
     fprintf(code, "jmp %s\n", after_otherwise_label);
 
     if (codegen_verbose) {
@@ -388,12 +384,12 @@ Error codegen_expression_x86_64_mswin
 
       expr = expression->children->next_child->next_child->children;
       while (expr) {
-        err = codegen_expression_x86_64_mswin(code, r, cg_context,
+        err = codegen_expression_x86_64_mswin(code, cg_context,
                                               ctx, &next_child_ctx,
                                               expr);
         if (err.type) { return err; }
         if (last_expr) {
-          register_deallocate(r, last_expr->result_register);
+          register_deallocate(cg_context, last_expr->result_register);
         }
         last_expr = expr;
         expr = expr->next_child;
@@ -401,12 +397,12 @@ Error codegen_expression_x86_64_mswin
       // Copy last_expr result register to if result register.
       if (last_expr) {
         fprintf(code, "mov %s, %s\n",
-                register_name(r, last_expr->result_register),
-                register_name(r, expression->result_register));
-        register_deallocate(r, last_expr->result_register);
+                register_name(cg_context, last_expr->result_register),
+                register_name(cg_context, expression->result_register));
+        register_deallocate(cg_context, last_expr->result_register);
       }
     } else {
-      fprintf(code, "mov $0, %s\n", register_name(r, expression->result_register));
+      fprintf(code, "mov $0, %s\n", register_name(cg_context, expression->result_register));
     }
 
     fprintf(code, "%s:\n", after_otherwise_label);
@@ -423,11 +419,11 @@ Error codegen_expression_x86_64_mswin
     //printf("Codegenning binary operator %s\n", expression->value.symbol);
     //print_node(tmpnode,0);
 
-    err = codegen_expression_x86_64_mswin(code, r, cg_context,
+    err = codegen_expression_x86_64_mswin(code, cg_context,
                                           context, next_child_context,
                                           expression->children);
     if (err.type) { return err; }
-    err = codegen_expression_x86_64_mswin(code, r, cg_context,
+    err = codegen_expression_x86_64_mswin(code, cg_context,
                                           context, next_child_context,
                                           expression->children->next_child);
     if (err.type) { return err; }
@@ -436,63 +432,63 @@ Error codegen_expression_x86_64_mswin
       // Greater than
       // https://www.felixcloutier.com/x86/cmovcc
 
-      expression->result_register = register_allocate(r);
-      RegisterDescriptor true_register = register_allocate(r);
+      expression->result_register = register_allocate(cg_context);
+      RegisterDescriptor true_register = register_allocate(cg_context);
 
-      fprintf(code, "mov $0, %s\n", register_name(r, expression->result_register));
-      fprintf(code, "mov $1, %s\n", register_name(r, true_register));
+      fprintf(code, "mov $0, %s\n", register_name(cg_context, expression->result_register));
+      fprintf(code, "mov $1, %s\n", register_name(cg_context, true_register));
       fprintf(code, "cmp %s, %s\n"
-              , register_name(r, expression->children->next_child->result_register)
-              , register_name(r, expression->children->result_register));
+              , register_name(cg_context, expression->children->next_child->result_register)
+              , register_name(cg_context, expression->children->result_register));
       fprintf(code, "cmovg %s, %s\n",
-              register_name(r, true_register),
-              register_name(r, expression->result_register));
+              register_name(cg_context, true_register),
+              register_name(cg_context, expression->result_register));
 
       // Free no-longer-used left hand side result register.
-      register_deallocate(r, true_register);
-      register_deallocate(r, expression->children->result_register);
-      register_deallocate(r, expression->children->next_child->result_register);
+      register_deallocate(cg_context, true_register);
+      register_deallocate(cg_context, expression->children->result_register);
+      register_deallocate(cg_context, expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "<") == 0) {
       // Less than
       // https://www.felixcloutier.com/x86/cmovcc
 
-      expression->result_register = register_allocate(r);
-      RegisterDescriptor true_register = register_allocate(r);
+      expression->result_register = register_allocate(cg_context);
+      RegisterDescriptor true_register = register_allocate(cg_context);
 
-      fprintf(code, "mov $0, %s\n", register_name(r, expression->result_register));
-      fprintf(code, "mov $1, %s\n", register_name(r, true_register));
+      fprintf(code, "mov $0, %s\n", register_name(cg_context, expression->result_register));
+      fprintf(code, "mov $1, %s\n", register_name(cg_context, true_register));
       fprintf(code, "cmp %s, %s\n"
-              , register_name(r, expression->children->next_child->result_register)
-              , register_name(r, expression->children->result_register)
+              , register_name(cg_context, expression->children->next_child->result_register)
+              , register_name(cg_context, expression->children->result_register)
               );
       fprintf(code, "cmovl %s, %s\n",
-              register_name(r, true_register),
-              register_name(r, expression->result_register));
+              register_name(cg_context, true_register),
+              register_name(cg_context, expression->result_register));
 
       // Free no-longer-used left hand side result register.
-      register_deallocate(r, true_register);
-      register_deallocate(r, expression->children->result_register);
-      register_deallocate(r, expression->children->next_child->result_register);
+      register_deallocate(cg_context, true_register);
+      register_deallocate(cg_context, expression->children->result_register);
+      register_deallocate(cg_context, expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "=") == 0) {
       // Equality
       // https://www.felixcloutier.com/x86/cmovcc
 
-      expression->result_register = register_allocate(r);
-      RegisterDescriptor true_register = register_allocate(r);
+      expression->result_register = register_allocate(cg_context);
+      RegisterDescriptor true_register = register_allocate(cg_context);
 
-      fprintf(code, "mov $0, %s\n", register_name(r, expression->result_register));
-      fprintf(code, "mov $1, %s\n", register_name(r, true_register));
+      fprintf(code, "mov $0, %s\n", register_name(cg_context, expression->result_register));
+      fprintf(code, "mov $1, %s\n", register_name(cg_context, true_register));
       fprintf(code, "cmp %s, %s\n",
-              register_name(r, expression->children->result_register),
-              register_name(r, expression->children->next_child->result_register));
+              register_name(cg_context, expression->children->result_register),
+              register_name(cg_context, expression->children->next_child->result_register));
       fprintf(code, "cmove %s, %s\n",
-              register_name(r, true_register),
-              register_name(r, expression->result_register));
+              register_name(cg_context, true_register),
+              register_name(cg_context, expression->result_register));
 
       // Free no-longer-used left hand side result register.
-      register_deallocate(r, true_register);
-      register_deallocate(r, expression->children->result_register);
-      register_deallocate(r, expression->children->next_child->result_register);
+      register_deallocate(cg_context, true_register);
+      register_deallocate(cg_context, expression->children->result_register);
+      register_deallocate(cg_context, expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "+") == 0) {
       // Plus/Addition
       // https://www.felixcloutier.com/x86/add
@@ -501,11 +497,11 @@ Error codegen_expression_x86_64_mswin
       expression->result_register = expression->children->next_child->result_register;
 
       fprintf(code, "add %s, %s\n",
-              register_name(r, expression->children->result_register),
-              register_name(r, expression->children->next_child->result_register));
+              register_name(cg_context, expression->children->result_register),
+              register_name(cg_context, expression->children->next_child->result_register));
 
       // Free no-longer-used left hand side result register.
-      register_deallocate(r, expression->children->result_register);
+      register_deallocate(cg_context, expression->children->result_register);
     } else if (strcmp(expression->value.symbol, "-") == 0) {
       // Minus/Subtraction
       // https://www.felixcloutier.com/x86/sub
@@ -514,11 +510,11 @@ Error codegen_expression_x86_64_mswin
       expression->result_register = expression->children->result_register;
 
       fprintf(code, "sub %s, %s\n",
-              register_name(r, expression->children->next_child->result_register),
-              register_name(r, expression->children->result_register));
+              register_name(cg_context, expression->children->next_child->result_register),
+              register_name(cg_context, expression->children->result_register));
 
       // Free no-longer-used left hand side result register.
-      register_deallocate(r, expression->children->next_child->result_register);
+      register_deallocate(cg_context, expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "*") == 0) {
       // Multiply
       // https://www.felixcloutier.com/x86/mul
@@ -528,11 +524,11 @@ Error codegen_expression_x86_64_mswin
       expression->result_register = expression->children->next_child->result_register;
 
       fprintf(code, "imul %s, %s\n",
-              register_name(r, expression->children->result_register),
-              register_name(r, expression->children->next_child->result_register));
+              register_name(cg_context, expression->children->result_register),
+              register_name(cg_context, expression->children->next_child->result_register));
 
       // Free no-longer-used left hand side result register.
-      register_deallocate(r, expression->children->result_register);
+      register_deallocate(cg_context, expression->children->result_register);
     } else if (strcmp(expression->value.symbol, "/") == 0
                || strcmp(expression->value.symbol, "%") == 0) {
       // Division/Modulo
@@ -559,7 +555,7 @@ Error codegen_expression_x86_64_mswin
 
       // Load RAX with left hand side of division operator, if needed.
       // TODO: Use enum comparison on RegisterDescriptor instead of strcmp()!
-      char *lhs_register_name = register_name(r,expression->children->result_register);
+      const char *lhs_register_name = register_name(cg_context,expression->children->result_register);
       if (strcmp(lhs_register_name, "%rax")) {
         // TODO: If RHS is in RAX, we must save RAX first...
         fprintf(code, "mov %s, %%rax\n", lhs_register_name);
@@ -573,10 +569,10 @@ Error codegen_expression_x86_64_mswin
       // Call IDIV with right hand side of division operator.
       fprintf(code,
               "idiv %s\n",
-              register_name(r, expression->children->next_child->result_register));
+              register_name(cg_context, expression->children->next_child->result_register));
 
-      expression->result_register = register_allocate(r);
-      char *result_register_name = register_name(r,expression->result_register);
+      expression->result_register = register_allocate(cg_context);
+      const char *result_register_name = register_name(cg_context, expression->result_register);
       if (modulo_flag) {
         // Move return value from RDX into wherever it actually belongs.
         fprintf(code, "mov %%rdx, %s\n", result_register_name);
@@ -603,11 +599,11 @@ Error codegen_expression_x86_64_mswin
               "mov %s, %%rcx\n"
               "sal %%cl, %s\n"
               "pop %%rcx\n",
-              register_name(r, expression->children->next_child->result_register),
-              register_name(r, expression->children->result_register));
+              register_name(cg_context, expression->children->next_child->result_register),
+              register_name(cg_context, expression->children->result_register));
 
       // Free no-longer-used right hand side result register.
-      register_deallocate(r, expression->children->next_child->result_register);
+      register_deallocate(cg_context, expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, ">>") == 0) {
       // Minus/Subtraction
       // https://www.felixcloutier.com/x86/sub
@@ -620,11 +616,11 @@ Error codegen_expression_x86_64_mswin
               "mov %s, %%rcx\n"
               "sar %%cl, %s\n"
               "pop %%rcx\n",
-              register_name(r, expression->children->next_child->result_register),
-              register_name(r, expression->children->result_register));
+              register_name(cg_context, expression->children->next_child->result_register),
+              register_name(cg_context, expression->children->result_register));
 
       // Free no-longer-used right hand side result register.
-      register_deallocate(r, expression->children->next_child->result_register);
+      register_deallocate(cg_context, expression->children->next_child->result_register);
     } else {
       fprintf(stderr, "Unrecognized binary operator: \"%s\"\n", expression->value.symbol);
       ERROR_PREP(err, ERROR_GENERIC, "codegen_expression_x86_64() does not recognize binary operator");
@@ -635,7 +631,7 @@ Error codegen_expression_x86_64_mswin
     if (codegen_verbose) {
       fprintf(code, ";;#; Variable Access: \"%s\"\n", expression->value.symbol);
     }
-    expression->result_register = register_allocate(r);
+    expression->result_register = register_allocate(cg_context);
 
     // Find context that local variable resides in.
 
@@ -650,7 +646,7 @@ Error codegen_expression_x86_64_mswin
       // Global variable
       fprintf(code, "mov %s(%%rip), %s\n",
               expression->value.symbol,
-              register_name(r, expression->result_register));
+              register_name(cg_context, expression->result_register));
     } else {
       // TODO: For each context change upwards (base pointer load), emit a call to load caller RBP
       // from current RBP into some register, and use that register as offset for memory access.
@@ -658,7 +654,7 @@ Error codegen_expression_x86_64_mswin
       // another time :^). Good luck, future me!
       fprintf(code, "mov %lld(%%rbp), %s\n",
               tmpnode->value.integer,
-              register_name(r, expression->result_register));
+              register_name(cg_context, expression->result_register));
     }
     break;
   case NODE_TYPE_VARIABLE_DECLARATION:
@@ -710,7 +706,7 @@ Error codegen_expression_x86_64_mswin
     }
 
     // Codegen RHS
-    err = codegen_expression_x86_64_mswin(code, r, cg_context, context, next_child_context,
+    err = codegen_expression_x86_64_mswin(code, cg_context, context, next_child_context,
                                           expression->children->next_child);
     if (err.type) { break; }
 
@@ -723,26 +719,26 @@ Error codegen_expression_x86_64_mswin
     } else {
       should_free_result = 1;
       // Codegen LHS
-      err = codegen_expression_x86_64_mswin(code, r, cg_context, context, next_child_context,
+      err = codegen_expression_x86_64_mswin(code, cg_context, context, next_child_context,
                                             expression->children);
       if (err.type) { break; }
-      result = register_name(r, expression->children->result_register);
+      const char *name = register_name(cg_context, expression->children->result_register);
       // Put parenthesis around `result`.
-      size_t needed_len = strlen(result) + 2;
-      char *result_copy = strdup(result);
+      size_t needed_len = strlen(name) + 2;
+      char *result_copy = strdup(name);
       result = malloc(needed_len + 1);
       snprintf(result, needed_len + 1, "(%s)", result_copy);
       result[needed_len] = '\0';
       free(result_copy);
     }
     fprintf(code, "mov %s, %s\n",
-            register_name(r, expression->children->next_child->result_register),
+            register_name(cg_context,  expression->children->next_child->result_register),
             result);
-    register_deallocate(r, expression->children->next_child->result_register);
+    register_deallocate(cg_context, expression->children->next_child->result_register);
 
     if (should_free_result) {
       free(result);
-      register_deallocate(r, expression->children->result_register);
+      register_deallocate(cg_context, expression->children->result_register);
     }
 
     break;
@@ -766,8 +762,7 @@ const char *function_footer_x86_64 =
   "pop %rbp\n"
   "ret\n";
 Error codegen_function_x86_64_att_asm_mswin
-(Register *r,
- CodegenContext *cg_context,
+(CodegenContext *cg_context,
  ParsingContext *context,
  ParsingContext **next_child_context,
  char *name,
@@ -777,7 +772,7 @@ Error codegen_function_x86_64_att_asm_mswin
 {
   Error err = ok;
 
-  cg_context = codegen_context_create(cg_context);
+  cg_context = codegen_context_create_x86_64_mswin(cg_context);
 
   // Store base pointer integer offset within locals environment
   // Start at one to make space for pushed RBP in function header.
@@ -823,8 +818,8 @@ Error codegen_function_x86_64_att_asm_mswin
   Node *last_expression = NULL;
   Node *expression = function->children->next_child->next_child->children;
   while (expression) {
-    err = codegen_expression_x86_64_mswin(code, r, cg_context, ctx, &next_child_ctx, expression);
-    register_deallocate(r, expression->result_register);
+    err = codegen_expression_x86_64_mswin(code, cg_context, ctx, &next_child_ctx, expression);
+    register_deallocate(cg_context, expression->result_register);
     if (err.type) {
       print_error(err);
       return err;
@@ -835,7 +830,7 @@ Error codegen_function_x86_64_att_asm_mswin
 
   // Copy last expression result register to RAX
   if (last_expression) {
-    char *name = register_name(r,last_expression->result_register);
+    const char *name = register_name(cg_context,last_expression->result_register);
     if (strcmp(name, "%rax")) {
       fprintf(code, "mov %s, %%rax\n", name);
     }
@@ -861,15 +856,8 @@ Error codegen_function_x86_64_att_asm_mswin
   return ok;
 }
 
-Error codegen_program_x86_64_mswin(FILE *code, CodegenContext* cg_context, ParsingContext *context, Node *program) {
+Error codegen_program_x86_64_mswin(FILE *code, CodegenContext *cg_context, ParsingContext *context, Node *program) {
   Error err = ok;
-
-  Register *r = register_create("%rax");
-  register_add(r, "%r10");
-  register_add(r, "%r11");
-  register_add(r, "%rbx");
-  register_add(r, "%rdi");
-  register_add(r, "%rsi");
 
   fprintf(code, "%s", ".section .data\n");
 
@@ -906,15 +894,15 @@ Error codegen_program_x86_64_mswin(FILE *code, CodegenContext* cg_context, Parsi
       expression = expression->next_child;
       continue;
     }
-    err = codegen_expression_x86_64_mswin(code, r, cg_context, context, &next_child_context, expression);
+    err = codegen_expression_x86_64_mswin(code, cg_context, context, &next_child_context, expression);
     if (err.type) { return err; }
-    register_deallocate(r, expression->result_register);
+    register_deallocate(cg_context, expression->result_register);
     last_expression = expression;
     expression = expression->next_child;
   }
 
   // TODO: Copy this code to the generic function for return value!
-  char *name = register_name(r,last_expression->result_register);
+  const char *name = register_name(cg_context, last_expression->result_register);
   if (strcmp(name, "%rax") != 0) {
     fprintf(code, "mov %s, %%rax\n", name);
   }
@@ -942,7 +930,7 @@ Error codegen_program
     ERROR_PREP(err, ERROR_ARGUMENTS, "codegen_program(): filepath can not be NULL!");
     return err;
   }
-  CodegenContext *cg_context = codegen_context_create(NULL);
+  CodegenContext *cg_context = codegen_context_create_x86_64_mswin(NULL);
   // Open file for writing.
   FILE *code = fopen(filepath, "w");
   if (!code) {

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -106,6 +106,7 @@ const char *register_name
   if (!register_descriptor_is_valid(cg_ctx, descriptor)) {
     printf("ERROR::register_name(): Could not find register with descriptor of %d\n",
            descriptor);
+    return NULL;
   }
   return cg_ctx->registers.regs[descriptor].name;
 }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -25,22 +25,29 @@ enum RegX86_64_MsWin {
 
 /// Creates a context for the CG_FMT_x86_64_MSWIN architecture.
 CodegenContext *codegen_context_x86_64_mswin_create(CodegenContext *parent) {
-  Register *registers = calloc(REG_X86_64_MSWIN_COUNT, sizeof *registers);
-  INIT_REGISTER(REG_X86_64_MSWIN_RAX, "%rax");
-  INIT_REGISTER(REG_X86_64_MSWIN_R10, "%r10");
-  INIT_REGISTER(REG_X86_64_MSWIN_R11, "%r11");
-  INIT_REGISTER(REG_X86_64_MSWIN_RBX, "%rbx");
-  INIT_REGISTER(REG_X86_64_MSWIN_RDI, "%rdi");
-  INIT_REGISTER(REG_X86_64_MSWIN_RSI, "%rsi");
+  RegisterPool pool;
 
-  RegisterPool register_pool = {
-    .regs = registers,
-    .num_regs = REG_X86_64_MSWIN_COUNT,
-  };
+  // Create the registers if this is the top-level context.
+  if (!parent) {
+    Register *registers = calloc(REG_X86_64_MSWIN_COUNT, sizeof *registers);
+    INIT_REGISTER(REG_X86_64_MSWIN_RAX, "%rax");
+    INIT_REGISTER(REG_X86_64_MSWIN_R10, "%r10");
+    INIT_REGISTER(REG_X86_64_MSWIN_R11, "%r11");
+    INIT_REGISTER(REG_X86_64_MSWIN_RBX, "%rbx");
+    INIT_REGISTER(REG_X86_64_MSWIN_RDI, "%rdi");
+    INIT_REGISTER(REG_X86_64_MSWIN_RSI, "%rsi");
+
+    pool = (RegisterPool) {
+      .regs = registers,
+      .num_regs = REG_X86_64_MSWIN_COUNT,
+    };
+  } else {
+    pool = parent->registers;
+  }
 
   CodegenContext *cg_ctx = calloc(1,sizeof(CodegenContext));
   cg_ctx->parent = parent;
-  cg_ctx->registers = register_pool;
+  cg_ctx->registers = pool;
   cg_ctx->locals = environment_create(NULL);
   cg_ctx->locals_offset = -32;
   return cg_ctx;
@@ -50,8 +57,9 @@ CodegenContext *codegen_context_x86_64_mswin_create(CodegenContext *parent) {
 
 /// Free a context created by codegen_context_x86_64_mswin_create.
 void codegen_context_x86_64_mswin_free(CodegenContext *ctx) {
-  free(ctx->registers.regs);
-  /// TODO(sirraide): Free environment.
+  // Only free the registers if this is the top-level context.
+  if (!ctx->parent) free(ctx->registers.regs);
+  // TODO(sirraide): Free environment.
   free(ctx);
 }
 

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -8,35 +8,28 @@
 typedef int RegisterDescriptor;
 
 typedef struct Register {
-  struct Register *next;
   /// What will be emitted when referencing this register, i.e "%rax"
-  char *name;
+  const char *name;
   /// If non-zero, this register is in use.
   char in_use;
+  /// Identifies a register uniquely.
+  RegisterDescriptor descriptor;
 } Register;
 
-/// NAME is now owned by register.
-Register *register_create(char *name);
-
-/// NAME is now owned by register.
-void register_add(Register *base, char *name);
-
-void register_free(Register *base);
-
-RegisterDescriptor register_allocate(Register *base);
-void register_deallocate(Register *base, RegisterDescriptor register_descriptor);
-
-char *register_name(Register *base, RegisterDescriptor register_descriptor);
-
+/// Architecture-specific register information.
+typedef struct RegisterPool {
+  Register *regs;
+  size_t num_regs;
+} RegisterPool;
 
 char *label_generate();
-
 
 typedef struct CodegenContext {
   struct CodegenContext *parent;
   /// LOCALS
   /// `-- SYMBOL (NAME) -> INTEGER (STACK OFFSET)
   Environment *locals;
+  RegisterPool registers;
   long long locals_offset;
 } CodegenContext;
 


### PR DESCRIPTION
Summary
======
This pr is a major refactor to how registers are stored in code generation. Specifically, this is intended to simplify allocation/deallocation of and comparisons between registers.

All examples still compile properly and return the same values.

Registers
======
Previously, registers were allocated and freed one by one and passed as a separate parameter to numerous functions in the code generator.  This pr instead introduces the notion of a `RegisterPool`, a data structure which is used to store all the registers of a given architecture (though it itself is architecture-agnostic) and is a part of the `CodegenContext`. The `RegisterPool` is shallow-copied into each child context; the registers themselves are jointly allocated and freed in the top-level context only.

The `RegX86_64_MsWin` enum defines several enumerators (e.g. `REG_X86_64_MSWIN_RAX`) that serve as the register descriptors for the x86_64 registers. Registers can now be compared using those enumerators, which means that there is no longer a need to use `strcmp()` to check if a register is `rax`. That said, only the registers that were already defined using `register_add()` and friends have received corresponding enumerators. Other registers (e.g. `rdx`) do not have corresponding enumerators as of yet.

For the sake of simplicity, it may be worth considering using less verbose names than `REG_X86_64_MSWIN_RAX`.

Due to the fact that registers are unsurprisingly used throughout the entire code generator, the first commit ended up being rather extensive.

Further Changes
===========
This refactoring process has led to several additional changes in how certain things are handled in the code generator:
- Removed the declarations of all `register_*()` functions from codegen.h since these functions are only used in codegen.c
- Removed `register_create()`, `register_add()`, and `register_free()` since they are no longer used. On that note, the reason why `register_free()` wasn't working properly is because it was trying to `free()` string literals.
- Renamed `codegen_context_create()` to `codegen_context_x86_64_mswin_create()`; it now also initialises the x86_64 register pool.
- Added `codegen_context_x86_64_mswin_free()` which is used to deallocate contexts and eventually the register pool when passed the top-level contexts. This function is already in use and several TODOs referencing context deallocation have been removed. This function does nothing to clean up the context's environment, seeing as there currently seems to be no way of `free()`’ing environments.
- Removed the `next` pointer from `Register`. Iterating registers now exclusively makes use of register descriptors, which are now basically indices into an array of registers that is stored in the register pool. 
- Removed the `Register *r` parameter from all codegen functions. 
- Changed the type of `Register::name` as well as the return type of `register_name()` from `char*` to `const char*` since it is/returns a string literal. This also means that code using `register_name` had to be adjusted in several places.

On a side note, I have used `char` for `bool` in several places, even though I would normally use `bool` from `<stdbool.h>`, but since that is not what this pr is about, I have opted to continue using `char` for the time being.