### PR TITLE
Implement generic code generation for comparisons using setcc

### DIFF
--- a/examples/comparisons
+++ b/examples/comparisons
@@ -1,0 +1,19 @@
+;; Workaround because we don't support parentheses in expressions yet
+add : integer (a : integer b : integer) = integer (a : integer b : integer) {
+  a + b
+}
+
+a: integer = 0
+
+;; True
+a := add(a, 1 = 1)
+a := add(a, 1 < 2)
+a := add(a, 2 > 1)
+
+;; False
+a := add(a, 1 = 2)
+a := add(a, 1 > 2)
+a := add(a, 2 < 1)
+
+;; Should return 3
+a

--- a/examples/comparisons
+++ b/examples/comparisons
@@ -13,6 +13,8 @@ a := add(a, 2 > 1)
 ;; False
 a := add(a, 1 = 2)
 a := add(a, 1 > 2)
+a := add(a, 1 > 2)
+a := add(a, 2 < 1)
 a := add(a, 2 < 1)
 
 ;; Should return 3

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -21,7 +21,7 @@ enum ComparisonType {
   COMPARE_COUNT,
 };
 
-static const char *comparison_suffixes[COMPARE_COUNT] = {
+static const char *comparison_suffixes_x86_64[COMPARE_COUNT] = {
     "e",
     "ne",
     "l",
@@ -263,7 +263,7 @@ void codegen_comparison_x86_64_mswin
   fprintf(code, "cmp %s, %s\n",
       register_name(cg_context, expression->children->next_child->result_register),
       register_name(cg_context, expression->children->result_register));
-  fprintf(code, "set%s %%r8b\n", comparison_suffixes[type]);
+  fprintf(code, "set%s %%r8b\n", comparison_suffixes_x86_64[type]);
   register_deallocate(cg_context, expression->children->next_child->result_register);
 
   // Move the value into the result register and restore %r8 if it was in use.


### PR DESCRIPTION
This pr changes the code generator to use `setcc` + `%r8b` instead of `cmovcc` for generating comparisons. 

Furthermore, since code generation for all comparisons (`=`, `!=`, `<`, `<=`, `>`, `>=`) is *identical* except for the appropriate `setcc` instruction, I have extracted it into a separate function called `codegen_comparison_x86_64_mswin()`. That function also supports the remaining comparison operations that are not yet supported by the frontend.