### PR TITLE
¡Codegen Overhaul: Reloaded!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,19 @@ add_executable(
   src/main.c
   src/parser.c
   src/typechecker.c
+  src/codegen/codegen_platforms.c
+  src/codegen/x86_64/arch_x86_64.c
 )
 target_include_directories(
   func
   PUBLIC src/
+)
+target_compile_options(
+  func
+  PRIVATE
+  -Wall
+  -Wextra
+  -Werror=return-type
+  -Wno-unused-parameter
+  -Wno-unused-variable
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,3 @@ target_include_directories(
   func
   PUBLIC src/
 )
-target_compile_options(
-  func
-  PRIVATE
-  -Wall
-  -Wextra
-  -Werror=return-type
-  -Wno-unused-parameter
-  -Wno-unused-variable
-)

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -768,6 +768,7 @@ Error codegen_program(CodegenContext *cg_context, ParsingContext *context, Node 
 Error codegen
 (enum CodegenOutputFormat format,
  enum CodegenCallingConvention call_convention,
+ enum CodegenAssemblyDialect dialect,
  char *filepath,
  ParsingContext *context,
  Node *program
@@ -786,7 +787,7 @@ Error codegen
     return err;
   }
 
-  CodegenContext *cg_context = codegen_context_create_top_level(format, call_convention, code);
+  CodegenContext *cg_context = codegen_context_create_top_level(format, call_convention, dialect, code);
   err = codegen_program(cg_context, context, program);
   codegen_context_free(cg_context);
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -331,6 +331,9 @@ void femit_x86_64_reg_to_reg(CodegenContext *context, enum Instructions_x86_64 i
   const char *source = register_name(source_register);
   const char *destination = register_name(destination_register);
 
+  // Optimise away moves from a register to itself
+  if (inst == INSTRUCTION_X86_64_MOV && source_register == destination_register) return;
+
   switch (context->format) {
     case CG_FMT_x86_64_GAS:
       fprintf(context->code, "%s %%%s, %%%s\n",

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -604,6 +604,8 @@ Error codegen_expression
   return err;
 }
 
+#define LABEL_NAME_BUFFER_SIZE (1024)
+
 Error codegen_function
 (CodegenContext *cg_context,
  ParsingContext *context,
@@ -633,8 +635,8 @@ Error codegen_function
 
   // Nested function execution protection
 
-  char after_name_buffer[1024] = {0};
-  snprintf(after_name_buffer, 1024, "after%s", name);
+  char after_name_buffer[LABEL_NAME_BUFFER_SIZE];
+  snprintf(after_name_buffer, sizeof after_name_buffer, "after%s", name);
   after_name_buffer[sizeof after_name_buffer - 1] = 0;
   codegen_branch(cg_context, after_name_buffer);
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -19,9 +19,9 @@ char codegen_verbose = 1;
 /// order
 #define FOR_ALL_X86_64_REGISTERS(F)     \
   F(RAX, "rax", "eax", "ax", "al")      \
-  F(RBX, "rbx", "ebx", "bx", "bx")      \
-  F(RCX, "rcx", "ecx", "cx", "cx")      \
-  F(RDX, "rdx", "edx", "dx", "dx")      \
+  F(RBX, "rbx", "ebx", "bx", "bl")      \
+  F(RCX, "rcx", "ecx", "cx", "cl")      \
+  F(RDX, "rdx", "edx", "dx", "dl")      \
   F(R8,  "r8", "r8d", "r8w", "r8b")     \
   F(R9,  "r9", "r9d", "r9w", "r9b")     \
   F(R10, "r10", "r10d", "r10w", "r10b") \
@@ -75,154 +75,348 @@ DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name_8, 8)
 #undef DEFINE_REGISTER_ENUM
 #undef DEFINE_REGISTER_NAME_LOOKUP_FUNCTION
 
+/// Types of conditional jump instructions (Jcc).
+/// Do NOT reorder these.
+enum IndirectJumpType_x86_64 {
+  JUMP_TYPE_A,
+  JUMP_TYPE_AE,
+  JUMP_TYPE_B,
+  JUMP_TYPE_BE,
+  JUMP_TYPE_C,
+  JUMP_TYPE_E,
+  JUMP_TYPE_Z,
+  JUMP_TYPE_G,
+  JUMP_TYPE_GE,
+  JUMP_TYPE_L,
+  JUMP_TYPE_LE,
+  JUMP_TYPE_NA,
+  JUMP_TYPE_NAE,
+  JUMP_TYPE_NB,
+  JUMP_TYPE_NBE,
+  JUMP_TYPE_NC,
+  JUMP_TYPE_NE,
+  JUMP_TYPE_NG,
+  JUMP_TYPE_NGE,
+  JUMP_TYPE_NL,
+  JUMP_TYPE_NLE,
+  JUMP_TYPE_NO,
+  JUMP_TYPE_NP,
+  JUMP_TYPE_NS,
+  JUMP_TYPE_NZ,
+  JUMP_TYPE_O,
+  JUMP_TYPE_P,
+  JUMP_TYPE_PE,
+  JUMP_TYPE_PO,
+  JUMP_TYPE_S,
+
+  JUMP_TYPE_COUNT,
+};
+
+/// Do NOT reorder these.
+static const char *jump_type_names_x86_64[] = {
+  "a",
+  "ae",
+  "b",
+  "be",
+  "c",
+  "e",
+  "z",
+  "g",
+  "ge",
+  "l",
+  "le",
+  "na",
+  "nae",
+  "nb",
+  "nbe",
+  "nc",
+  "ne",
+  "ng",
+  "nge",
+  "nl",
+  "nle",
+  "no",
+  "np",
+  "ns",
+  "nz",
+  "o",
+  "p",
+  "pe",
+  "po",
+  "s",
+};
+
 // TODO: All instructions we use in x86_64 should be in this enum.
 enum Instructions_x86_64 {
+  /// Arithmetic instructions.
   INSTRUCTION_X86_64_ADD,
   INSTRUCTION_X86_64_SUB,
-  INSTRUCTION_X86_64_MUL,
+  // INSTRUCTION_X86_64_MUL,
   INSTRUCTION_X86_64_IMUL,
-  INSTRUCTION_X86_64_DIV,
+  // INSTRUCTION_X86_64_DIV,
   INSTRUCTION_X86_64_IDIV,
-  INSTRUCTION_X86_64_PUSH,
-  INSTRUCTION_X86_64_POP,
   INSTRUCTION_X86_64_XOR,
   INSTRUCTION_X86_64_CMP,
+  INSTRUCTION_X86_64_TEST,
+  INSTRUCTION_X86_64_CQO,
+  INSTRUCTION_X86_64_SETCC,
+  INSTRUCTION_X86_64_SAL, ///< RegisterDescriptor reg | Immediate imm, RegisterDescriptor reg
+  INSTRUCTION_X86_64_SHL = INSTRUCTION_X86_64_SAL,
+  INSTRUCTION_X86_64_SAR, ///< RegisterDescriptor reg | Immediate imm, RegisterDescriptor reg
+  INSTRUCTION_X86_64_SHR, ///< RegisterDescriptor reg | Immediate imm, RegisterDescriptor reg
+
+  /// Stack instructions.
+  INSTRUCTION_X86_64_PUSH,
+  INSTRUCTION_X86_64_POP,
+
+  /// Control flow.
   INSTRUCTION_X86_64_CALL,
+  INSTRUCTION_X86_64_JMP, ///< const char* label | RegisterDescriptor reg
   INSTRUCTION_X86_64_RET,
+  INSTRUCTION_X86_64_JCC, ///< enum IndirectJumpType_x86_64 type, const char* label
+
+  /// Memory stuff.
   INSTRUCTION_X86_64_MOV,
   INSTRUCTION_X86_64_LEA,
-  INSTRUCTION_X86_64_SETCC,
+
   INSTRUCTION_X86_64_COUNT
 };
 
 enum InstructionOperands_x86_64 {
-  IMMEDIATE,
-  MEMORY,
-  REGISTER,
-  NAME,
+  IMMEDIATE, ///< int64_t imm
+  MEMORY,    ///< RegisterDescriptor reg, int64_t offset
+  REGISTER,  ///< RegisterDescriptor reg
+  NAME,      ///< const char* name
 
-  IMMEDIATE_TO_REGISTER,
-  IMMEDIATE_TO_MEMORY,
-  MEMORY_TO_REGISTER,
-  NAME_TO_REGISTER,
-  REGISTER_TO_REGISTER,
-  REGISTER_TO_MEMORY,
-
+  IMMEDIATE_TO_REGISTER, ///< int64_t imm, RegisterDescriptor dest
+  IMMEDIATE_TO_MEMORY,   ///< int64_t imm, RegisterDescriptor address, int64_t offset
+  MEMORY_TO_REGISTER,    ///< RegisterDescriptor address, int64_t offset, RegisterDescriptor dest
+  NAME_TO_REGISTER,      ///< RegisterDescriptor address, const char* name, RegisterDescriptor dest
+  REGISTER_TO_MEMORY,    ///< RegisterDescriptor src, RegisterDescriptor address, int64_t offset
+  REGISTER_TO_REGISTER,  ///< RegisterDescriptor src, RegisterDescriptor dest
+  REGISTER_TO_NAME,      ///< RegisterDescriptor src, RegisterDescriptor address, const char* name
 };
 
 const char *instruction_mnemonic_x86_64(enum CodegenOutputFormat fmt, enum Instructions_x86_64 instruction) {
-  ASSERT(INSTRUCTION_X86_64_COUNT == 15, "ERROR: instruction_mnemonic_x86_64() must exhaustively handle all instructions.");
+  ASSERT(INSTRUCTION_X86_64_COUNT == 20, "ERROR: instruction_mnemonic_x86_64() must exhaustively handle all instructions.");
   // x86_64 instructions that aren't different across syntaxes can go here!
   switch (instruction) {
-  default:
-    break;
-  case INSTRUCTION_X86_64_ADD:
-    return "add";
-  case INSTRUCTION_X86_64_SUB:
-    return "sub";
-  case INSTRUCTION_X86_64_MUL:
-    return "mul";
-  case INSTRUCTION_X86_64_IMUL:
-    return "imul";
-  case INSTRUCTION_X86_64_DIV:
-    return "div";
-  case INSTRUCTION_X86_64_IDIV:
-    return "idiv";
-  case INSTRUCTION_X86_64_PUSH:
-    return "push";
-  case INSTRUCTION_X86_64_POP:
-    return "pop";
-  case INSTRUCTION_X86_64_XOR:
-    return "xor";
-  case INSTRUCTION_X86_64_CMP:
-    return "cmp";
-  case INSTRUCTION_X86_64_CALL:
-    return "call";
-  case INSTRUCTION_X86_64_RET:
-    return "ret";
-  case INSTRUCTION_X86_64_MOV:
-    return "mov";
-  case INSTRUCTION_X86_64_LEA:
-    return "lea";
-  case INSTRUCTION_X86_64_SETCC:
-    return "set";
+    default: break;
+    case INSTRUCTION_X86_64_ADD: return "add";
+    case INSTRUCTION_X86_64_SUB: return "sub";
+    // case INSTRUCTION_X86_64_MUL: return "mul";
+    case INSTRUCTION_X86_64_IMUL: return "imul";
+    // case INSTRUCTION_X86_64_DIV: return "div";
+    case INSTRUCTION_X86_64_IDIV: return "idiv";
+    case INSTRUCTION_X86_64_SAL: return "sal";
+    case INSTRUCTION_X86_64_SAR: return "sar";
+    case INSTRUCTION_X86_64_SHR: return "shr";
+    case INSTRUCTION_X86_64_PUSH: return "push";
+    case INSTRUCTION_X86_64_POP: return "pop";
+    case INSTRUCTION_X86_64_XOR: return "xor";
+    case INSTRUCTION_X86_64_CMP: return "cmp";
+    case INSTRUCTION_X86_64_CALL: return "call";
+    case INSTRUCTION_X86_64_JMP: return "jmp";
+    case INSTRUCTION_X86_64_RET: return "ret";
+    case INSTRUCTION_X86_64_MOV: return "mov";
+    case INSTRUCTION_X86_64_LEA: return "lea";
+    case INSTRUCTION_X86_64_SETCC: return "set";
+    case INSTRUCTION_X86_64_TEST: return "test";
+    case INSTRUCTION_X86_64_JCC: return "j";
   }
-  panic("Could not convert instruction into mnemonic for x86_64");
-  return NULL; // Unreachable
+
+  switch (fmt) {
+    default: panic("instruction_mnemonic_x86_64(): Unknown output format.");
+
+    case CG_FMT_x86_64_GAS:
+    switch (instruction) {
+      default: panic("instruction_mnemonic_x86_64(): Unknown instruction.");
+      case INSTRUCTION_X86_64_CQO: return "cqto";
+    }
+  }
 }
 
-void femit_x86_64_imm_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_imm_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
   int64_t immediate                    = va_arg(args, int64_t);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
 
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
   const char *destination = register_name(destination_register);
 
-  fprintf(context->code, "%s $%" PRId64 ", %s\n",
-          mnemonic, immediate, destination);
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s $%" PRId64 ", %%%s\n",
+              mnemonic, immediate, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_imm_to_reg(): Unsupported format %d", context->format);
+  }
 }
 
-void femit_x86_64_imm_to_mem(CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_imm_to_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
   int64_t immediate                    = va_arg(args, int64_t);
   RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
   int64_t offset                       = va_arg(args, int64_t);
 
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
   const char *address = register_name(address_register);
 
-  fprintf(context->code, "%s $%" PRId64 ", %" PRId64 "(%s)\n",
-          mnemonic, immediate, offset, address);
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s $%" PRId64 ", %" PRId64 "(%%%s)\n",
+              mnemonic, immediate, offset, address);
+      break;
+    default: panic("ERROR: femit_x86_64_imm_to_mem(): Unsupported format %d", context->format);
+  }
 }
 
-void femit_x86_64_mem_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_mem_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
   int64_t offset                           = va_arg(args, int64_t);
-  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
 
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
   const char *address = register_name(address_register);
   const char *destination = register_name(destination_register);
 
-  fprintf(context->code,
-          "%s %" PRId64 "(%s), %s\n",
-          mnemonic, offset, address, destination);
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %" PRId64 "(%%%s), %%%s\n",
+              mnemonic, offset, address, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_mem_to_reg(): Unsupported format %d", context->format);
+  }
 }
 
-void femit_x86_64_name_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_name_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
   char *name                               = va_arg(args, char *);
-  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
 
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
   const char *address = register_name(address_register);
   const char *destination = register_name(destination_register);
 
-  fprintf(context->code,
-          "%s %s(%s), %s\n",
-          mnemonic, name, address, destination);
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %s(%%%s), %%%s\n",
+              mnemonic, name, address, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_name_to_reg(): Unsupported format %d", context->format);
+  }
 }
 
-void femit_x86_64_reg_to_mem(CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_reg_to_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
   RegisterDescriptor source_register   = va_arg(args, RegisterDescriptor);
   RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
   int64_t offset                       = va_arg(args, int64_t);
 
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
   const char *source = register_name(source_register);
   const char *address = register_name(address_register);
 
-  fprintf(context->code,
-          "%s %s, %" PRId64 "(%s)\n",
-          mnemonic, source, offset, address);
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s, %" PRId64 "(%%%s)\n",
+              mnemonic, source, offset, address);
+      break;
+    default: panic("ERROR: femit_x86_64_reg_to_mem(): Unsupported format %d", context->format);
+  }
 }
 
-void femit_x86_64_reg_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_reg_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
   RegisterDescriptor source_register       = va_arg(args, RegisterDescriptor);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
 
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
   const char *source = register_name(source_register);
   const char *destination = register_name(destination_register);
 
-  fprintf(context->code,
-          "%s %s, %s\n",
-          mnemonic, source, destination);
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s, %%%s\n",
+              mnemonic, source, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_reg_to_reg(): Unsupported format %d", context->format);
+  }
 }
 
+void femit_x86_64_reg_to_name(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor source_register  = va_arg(args, RegisterDescriptor);
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
+  char *name                               = va_arg(args, char *);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *source = register_name(source_register);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s, %s(%%%s)\n",
+          mnemonic, source, name, address);
+      break;
+    default: panic("ERROR: femit_x86_64_reg_to_name(): Unsupported format %d", context->format);
+  }
+}
+
+void femit_x86_64_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  int64_t offset                           = va_arg(args, int64_t);
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %" PRId64 "(%%%s)\n",
+              mnemonic, offset, address);
+      break;
+    default: panic("ERROR: femit_x86_64_mem(): Unsupported format %d", context->format);
+  }
+}
+
+void femit_x86_64_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor source_register   = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *source = register_name(source_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s\n",
+              mnemonic, source);
+      break;
+    default: panic("ERROR: femit_x86_64_reg(): Unsupported format %d", context->format);
+  }
+}
+
+void femit_x86_64_imm(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  int64_t immediate = va_arg(args, int64_t);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s $%" PRId64 "\n",
+              mnemonic, immediate);
+      break;
+    default: panic("ERROR: femit_x86_64_imm(): Unsupported format %d", context->format);
+  }
+}
+
+void femit_x86_64_indirect_branch(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor address_register   = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s *%%%s\n",
+              mnemonic, address);
+      break;
+    default: panic("ERROR: femit_x86_64_indirect_branch(): Unsupported format %d", context->format);
+  }
+}
 
 void femit_x86_64
 (CodegenContext *context,
@@ -233,182 +427,159 @@ void femit_x86_64
   va_list args;
   va_start(args, instruction);
 
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
-
   ASSERT(context);
-  switch (context->format) {
-  default:
-    break;
-  case CG_FMT_x86_64_GAS: {
-    ASSERT(INSTRUCTION_X86_64_COUNT == 15, "femit_x86_64() must exhaustively handle all x86_64 instructions for GAS syntax.");
-    switch (instruction) {
-    default:
-      panic("Unhandled instruction in x86_64 GAS code generation.");
-    case INSTRUCTION_X86_64_ADD:
-    case INSTRUCTION_X86_64_SUB:
-    case INSTRUCTION_X86_64_MOV: {
-      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
-      switch (operands) {
-      default:
-        panic("Unhandled operand type in x86_64 GAS code generation for MOV.");
-      case IMMEDIATE_TO_REGISTER:
-        // femit(..., IMMEDIATE_TO_REGISTER, (int64_t)immediate value, (RegisterDescriptor) destination)
-        femit_x86_64_imm_to_reg(context, mnemonic, args);
-        break;
-      case IMMEDIATE_TO_MEMORY:
-        // femit(..., IMMEDIATE_TO_MEMORY, (int64_t)immediate value, (RegisterDescriptor) memory_address, (int64_t) memory_offset)
-        femit_x86_64_imm_to_mem(context, mnemonic, args);
-        break;
-      case MEMORY_TO_REGISTER:
-        // femit(..., MEMORY_TO_REGISTER, (int64_t)memory_offset, (RegisterDescriptor) memory_address, (RegisterDescriptor) destination)
-        femit_x86_64_mem_to_reg(context, mnemonic, args);
-        break;
-      case REGISTER_TO_MEMORY:
-        // femit(..., REGISTER_TO_MEMORY, (RegisterDescriptor) source, (RegisterDescriptor) address, (int64_t) memory_offset)
-        femit_x86_64_reg_to_mem(context, mnemonic, args);
-        break;
-      case REGISTER_TO_REGISTER:
-        // femit(..., REGISTER_TO_REGISTER, (RegisterDescriptor) source, (RegisterDescriptor) destination)
-        femit_x86_64_reg_to_reg(context, mnemonic, args);
-        break;
-      }
-      break;
-    }
-    case INSTRUCTION_X86_64_LEA: {
-      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
-      switch (operands) {
-      default:
-        panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or NAME_TO_REGISTER operand type with LEA instruction.");
-      case MEMORY_TO_REGISTER:
-        // femit(..., MEMORY_TO_REGISTER, (int64_t) memory_offset, (RegisterDescriptor) memory_address, (RegisterDescriptor) destination)
-        femit_x86_64_mem_to_reg(context, mnemonic, args);
-        break;
-      case NAME_TO_REGISTER:
-        // femit(..., MEMORY_TO_REGISTER, (char *) name, (RegisterDescriptor) memory_address, (RegisterDescriptor) destination)
-        femit_x86_64_name_to_reg(context, mnemonic, args);
-        break;
-      }
-      break;
-    }
-    case INSTRUCTION_X86_64_IMUL: {
-      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
-      switch (operands) {
-      default:
-        panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or REGISTER_TO_REGISTER operand type with IMUL instruction.");
-        break;
-      case MEMORY_TO_REGISTER:
-        femit_x86_64_mem_to_reg(context, mnemonic, args);
-        break;
-      case REGISTER_TO_REGISTER:
-        femit_x86_64_reg_to_reg(context, mnemonic, args);
-        break;
-      }
-      break;
-    }
-    case INSTRUCTION_X86_64_IDIV: {
-      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
-      switch (operands) {
-      default:
-        panic("femit_x86_64() only accepts MEMORY or REGISTER operand type with IDIV instruction.");
-        break;
-      case MEMORY: {
-        // femit(..., MEMORY, (int64_t) memory_offset, (RegisterDescriptor) memory_address);
-        int64_t offset                           = va_arg(args, int64_t);
-        RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
+  ASSERT(INSTRUCTION_X86_64_COUNT == 20, "femit_x86_64() must exhaustively handle all x86_64 instructions.");
 
-        const char *destination = register_name(destination_register);
+  switch (instruction) {
+  case INSTRUCTION_X86_64_ADD:
+  case INSTRUCTION_X86_64_SUB:
+  case INSTRUCTION_X86_64_TEST:
+  case INSTRUCTION_X86_64_XOR:
+  case INSTRUCTION_X86_64_CMP:
+  case INSTRUCTION_X86_64_MOV: {
+    enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operands) {
+      default: panic("Unhandled operand type %d in x86_64 code generation for %d.", operands, instruction);
+      case IMMEDIATE_TO_REGISTER: femit_x86_64_imm_to_reg(context, instruction, args); break;
+      case IMMEDIATE_TO_MEMORY: femit_x86_64_imm_to_mem(context, instruction, args); break;
+      case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
+      case REGISTER_TO_MEMORY: femit_x86_64_reg_to_mem(context, instruction, args); break;
+      case REGISTER_TO_REGISTER: femit_x86_64_reg_to_reg(context, instruction, args); break;
+      case REGISTER_TO_NAME: femit_x86_64_reg_to_name(context, instruction, args); break;
+      case NAME_TO_REGISTER: femit_x86_64_name_to_reg(context, instruction, args); break;
+    }
+  } break;
 
-        fprintf(context->code, "%s %" PRId64 "(%s)\n",
-                mnemonic, offset, destination);
-        break;
-      }
+  case INSTRUCTION_X86_64_LEA: {
+    enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operands) {
+      default: panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or NAME_TO_REGISTER operand type with LEA instruction.");
+      case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
+      case NAME_TO_REGISTER: femit_x86_64_name_to_reg(context, instruction, args); break;
+    }
+  } break;
+
+  case INSTRUCTION_X86_64_IMUL: {
+    enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operands) {
+      default: panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or REGISTER_TO_REGISTER operand type with IMUL instruction.");
+      case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
+      case REGISTER_TO_REGISTER: femit_x86_64_reg_to_reg(context, instruction, args); break;
+    }
+  } break;
+
+  case INSTRUCTION_X86_64_IDIV: {
+    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operand) {
+      default: panic("femit_x86_64() only accepts MEMORY or REGISTER operand type with IDIV instruction.");
+      case MEMORY: femit_x86_64_mem(context, instruction, args); break;
+      case REGISTER: femit_x86_64_reg(context, instruction, args); break;
+    }
+  } break;
+
+  case INSTRUCTION_X86_64_SAL:
+  case INSTRUCTION_X86_64_SAR:
+  case INSTRUCTION_X86_64_SHR: {
+    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operand) {
+      default: panic("femit_x86_64() only accepts REGISTER OR IMMEDIATE_TO_REGISTER operand type with shift instructions.");
+      case IMMEDIATE_TO_REGISTER: femit_x86_64_imm_to_reg(context, instruction, args); break;
       case REGISTER: {
-        // femit(..., REGISTER, (RegisterDescriptor) source);
-        RegisterDescriptor source_register = va_arg(args, RegisterDescriptor);
+        RegisterDescriptor register_to_shift = va_arg(args, RegisterDescriptor);
+        const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+        const char *cl = register_name_8(REG_X86_64_RCX);
 
-        const char *source = register_name(source_register);
+        switch (context->format) {
+          case CG_FMT_x86_64_GAS:
+            fprintf(context->code, "%s %%%s, %%%s\n",
+                    mnemonic, cl, register_name(register_to_shift));
+            break;
+          default: panic("ERROR: femit_x86_64(): Unsupported format %d for shift instruction", context->format);
+        }
+      } break;
+    }
+  } break;
 
-        fprintf(context->code, "%s %s\n",
-                mnemonic, source);
+  case INSTRUCTION_X86_64_JMP:
+  case INSTRUCTION_X86_64_CALL: {
+    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operand) {
+      default: panic("femit_x86_64() only accepts REGISTER or NAME operand type with CALL/JMP instruction.");
+      case REGISTER: femit_x86_64_indirect_branch(context, instruction, args); break;
+      case NAME: {
+        char *label = va_arg(args, char *);
+        const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+
+        switch (context->format) {
+          case CG_FMT_x86_64_GAS:
+            fprintf(context->code, "%s %s\n",
+                mnemonic, label);
+            break;
+          default: panic("ERROR: femit_x86_64(): Unsupported format %d for CALL/JMP instruction", context->format);
+        }
+      } break;
+    }
+  } break;
+
+  case INSTRUCTION_X86_64_PUSH: {
+    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operand) {
+      default: panic("femit_x86_64() only accepts REGISTER, MEMORY, or IMMEDIATE operand type with PUSH instruction.");
+      case REGISTER: femit_x86_64_reg(context, instruction, args); break;
+      case MEMORY: femit_x86_64_mem(context, instruction, args); break;
+      case IMMEDIATE: femit_x86_64_imm(context, instruction, args); break;
+    }
+  } break;
+
+  case INSTRUCTION_X86_64_POP: {
+    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+    switch (operand) {
+      default: panic("femit_x86_64() only accepts REGISTER or MEMORY operand type with POP instruction.");
+      case REGISTER: femit_x86_64_reg(context, instruction, args); break;
+      case MEMORY: femit_x86_64_mem(context, instruction, args); break;
+    }
+  } break;
+
+  case INSTRUCTION_X86_64_SETCC: {
+    enum ComparisonType comparison_type = va_arg(args, enum ComparisonType);
+    RegisterDescriptor value_register = va_arg(args, RegisterDescriptor);
+
+    const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+    const char *value = register_name_8(value_register);
+
+    switch (context->format) {
+      case CG_FMT_x86_64_GAS:
+        fprintf(context->code, "%s%s %%%s\n",
+            mnemonic,
+            comparison_suffixes_x86_64[comparison_type], value);
         break;
-      }
-      }
-      break;
+      default: panic("ERROR: femit_x86_64(): Unsupported format %d", context->format);
     }
-    case INSTRUCTION_X86_64_CALL: {
-      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+  } break;
 
-      if (operand == REGISTER) {
-        RegisterDescriptor call_register = va_arg(args, RegisterDescriptor);
+  case INSTRUCTION_X86_64_JCC: {
+    enum IndirectJumpType_x86_64 type = va_arg(args, enum IndirectJumpType_x86_64);
+    ASSERT(type < JUMP_TYPE_COUNT, "femit_x86_64_direct_branch(): Invalid jump type %d", type);
+    char *label = va_arg(args, char *);
 
-        const char *call_address = register_name(call_register);
+    const char *mnemonic = instruction_mnemonic_x86_64(context->format, INSTRUCTION_X86_64_JCC);
 
-        fprintf(context->code, "%s *%s\n",
-                mnemonic, call_address);
-
-      } else if (operand == NAME) {
-        char *name = va_arg(args, char *);
-
-        fprintf(context->code, "%s %s\n",
-                mnemonic, name);
-
-      } else {
-        panic("femit_x86_64() only accepts REGISTER or NAME operand type with CALL instruction.");
-      }
-
-      break;
-    }
-    case INSTRUCTION_X86_64_PUSH: {
-      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
-      if (operand == REGISTER) {
-        // femit(..., REGISTER, (RegisterDescriptor) value_to_push)
-        RegisterDescriptor value_register = va_arg(args, RegisterDescriptor);
-
-        const char *value = register_name(value_register);
-
-        fprintf(context->code, "%s %s\n",
-                mnemonic, value);
-      } else if (operand == MEMORY) {
-        // femit(..., MEMORY, (RegisterDescriptor) memory_address, (int64_t) memory_offset)
-        RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
-        int64_t offset                       = va_arg(args, RegisterDescriptor);
-
-        const char *address = register_name(address_register);
-
-        fprintf(context->code, "%s %" PRId64 "(%s)",
-                mnemonic, offset, address);
-
-      } else if (operand == IMMEDIATE) {
-        // femit(..., IMMEDIATE, (int64_t) immediate)
-        int64_t immediate = va_arg(args, RegisterDescriptor);
-
-        fprintf(context->code, "%s $%" PRId64 "\n",
-                mnemonic, immediate);
-
-      } else {
-        panic("femit_x86_64() only accepts REGISTER, MEMORY, or IMMEDIATE operand type with PUSH instruction.");
-      }
-      break;
-    }
-    case INSTRUCTION_X86_64_SETCC: {
-      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
-      if (operand == REGISTER) {
-        // femit(..., ComparisonType, REGISTER)
-        enum ComparisonType comparison_type = va_arg(args, enum ComparisonType);
-        RegisterDescriptor value_register = va_arg(args, RegisterDescriptor);
-
-        const char *value = register_name_8(value_register);
-
+    switch (context->format) {
+      case CG_FMT_x86_64_GAS:
         fprintf(context->code, "%s%s %s\n",
-                mnemonic, comparison_suffixes_x86_64[comparison_type], value);
-      } else {
-        panic("femit_x86_64() SETcc only accepts a REGISTER operand");
-      }
-      break;
+            mnemonic, jump_type_names_x86_64[type], label);
+        break;
+      default: panic("ERROR: femit_x86_64_direct_branch(): Unsupported format %d", context->format);
     }
-    }
-    break;
-  }
+  } break;
+
+  case INSTRUCTION_X86_64_RET:
+  case INSTRUCTION_X86_64_CQO: {
+    const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+    fprintf(context->code, "%s\n", mnemonic);
+  } break;
+
+  default: panic("Unhandled instruction in x86_64 code generation: %d.", instruction);
   }
 
   va_end(args);
@@ -538,50 +709,64 @@ static char *label_generate() {
   return label;
 }
 
-#define symbol_buffer_size 1024
-char symbol_buffer[symbol_buffer_size];
-size_t symbol_index = 0;
-size_t symbol_count = 0;
-// TODO: Return Error and bubble, but makes it annoying.
-char *symbol_to_address(CodegenContext *cg_ctx, Node *symbol) {
-  if (!cg_ctx) {
-    printf("ERROR::symbol_to_address(): Context must not be NULL (pass global).\n");
-    return NULL;
-  }
-  if (!symbol || !symbol->value.symbol) {
-    printf("ERROR::symbol_to_address(): A symbol must be passed.\n");
-    print_node(symbol,2);
-    return NULL;
-  }
-  char *symbol_string = symbol_buffer + symbol_index;
+/// The address of a local or global symbol, or an error
+/// indicating why the symbol could not be found.
+typedef struct symbol_address {
+  enum {
+    /// Global variable. The address is in `global`.
+    SYMBOL_ADDRESS_MODE_GLOBAL,
+    /// Local variable. The address is in `local`.
+    SYMBOL_ADDRESS_MODE_LOCAL,
+    /// There was an error. The error is in `error`.
+    SYMBOL_ADDRESS_MODE_ERROR,
+  } mode;
+  union {
+    Error error;
+    const char *global;
+    long long int local;
+  };
+} symbol_address;
+
+symbol_address symbol_to_address(CodegenContext *cg_ctx, Node *symbol) {
+  ASSERT(cg_ctx, "symbol_to_address(): Context must not be NULL (pass global).");
+  ASSERT(symbol && symbol->value.symbol, "symbol_to_address(): A symbol must be passed.");
+
+  // Global variable access.
   if (!cg_ctx->parent) {
-    // Global variable access.
-    symbol_index += snprintf(symbol_string,
-                             symbol_buffer_size - symbol_index,
-                             "%s(%%rip)",
-                             symbol->value.symbol);
-  } else {
-    // Local variable access.
-    Node *stack_offset = node_allocate();
-    if (!environment_get(*cg_ctx->locals, symbol, stack_offset)) {
-      putchar('\n');
-      print_node(symbol,0);
-      environment_print(*cg_ctx->locals, 0);
-      printf("ERROR: symbol_to_address() Could not find \"%s\" in locals environment.\n",
-             symbol->value.symbol);
-      return NULL;
-    }
-    symbol_index += snprintf(symbol_string,
-                             symbol_buffer_size - symbol_index,
-                             "%lld(%%rbp)", stack_offset->value.integer);
-    free(stack_offset);
+    return (symbol_address) {
+        .mode = SYMBOL_ADDRESS_MODE_GLOBAL,
+        .global = symbol->value.symbol,
+    };
   }
-  symbol_index++;
-  if (symbol_index >= symbol_buffer_size) {
-    symbol_index = 0;
-    return symbol_to_address(cg_ctx, symbol);
+
+  // Local variable access.
+  Node *stack_offset = node_allocate();
+  if (!environment_get(*cg_ctx->locals, symbol, stack_offset)) {
+    putchar('\n');
+    print_node(symbol,0);
+    environment_print(*cg_ctx->locals, 0);
+
+    // FIXME(Sirraide): This is ugly. Should this be heap-allocated?
+    //   Maybe we should have a way to store a heap allocated string in
+    //   an `Error`? I would recommend either adding a flag indicating
+    //   that the messages needs to be free()’d or just leaking the
+    //   memory since we're probably going to terminate anyway if there
+    //   was an error.
+    static char err_buf[1024];
+    snprintf(err_buf, sizeof err_buf, "symbol_to_address(): Could not find symbol '%s' in environment.", symbol->value.symbol);
+    ERROR_CREATE(err, ERROR_GENERIC, err_buf);
+    return (symbol_address) {
+      .mode = SYMBOL_ADDRESS_MODE_ERROR,
+      .error = err,
+    };
   }
-  return symbol_string;
+
+  long long int address = stack_offset->value.integer;
+  free(stack_offset);
+  return (symbol_address) {
+    .mode = SYMBOL_ADDRESS_MODE_LOCAL,
+    .local = address,
+  };
 }
 
 const char *comparison_suffixes_x86_64[COMPARE_COUNT] = {
@@ -751,7 +936,7 @@ Error codegen_expression_x86_64
       femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                    REG_X86_64_RAX, expression->result_register);
       // Save overwritten in-use registers.
-      fprintf(code, "pop %%rax\n");
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP, REGISTER, REG_X86_64_RAX);
     } else {
       femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
                    (int64_t)8, REG_X86_64_RSP);
@@ -784,7 +969,8 @@ Error codegen_expression_x86_64
     // Function returns beginning of instructions address.
     expression->result_register = register_allocate(cg_context);
     femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
-                 result, REG_X86_64_RIP, expression->result_register);
+                 REG_X86_64_RIP, result,
+                 expression->result_register);
     break;
   case NODE_TYPE_DEREFERENCE:
     if (codegen_verbose) {
@@ -796,16 +982,28 @@ Error codegen_expression_x86_64
     if (err.type) { return err; }
     expression->result_register = expression->children->result_register;
     break;
-  case NODE_TYPE_ADDRESSOF:
+  case NODE_TYPE_ADDRESSOF: {
     if (codegen_verbose) {
       fprintf(code, ";;#; Addressof\n");
     }
     expression->result_register = register_allocate(cg_context);
-    fprintf(code, "lea %s, %s\n",
-            symbol_to_address(cg_context, expression->children),
-            register_name(expression->result_register));
+    symbol_address address = symbol_to_address(cg_context, expression->children);
+    switch (address.mode) {
+      case SYMBOL_ADDRESS_MODE_ERROR: return address.error;
+      case SYMBOL_ADDRESS_MODE_GLOBAL:
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
+                     REG_X86_64_RIP, address.global,
+                     expression->result_register);
+        break;
+      case SYMBOL_ADDRESS_MODE_LOCAL:
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, MEMORY_TO_REGISTER,
+                     REG_X86_64_RBP, address.local,
+                     expression->result_register);
+        break;
+    }
     break;
-  case NODE_TYPE_INDEX:
+  }
+  case NODE_TYPE_INDEX: {
     if (codegen_verbose) {
       fprintf(code, ";;#; Index %lld\n", expression->value.integer);
     }
@@ -825,15 +1023,27 @@ Error codegen_expression_x86_64
 
     // Load memory address of beginning of array.
     expression->result_register = register_allocate(cg_context);
-    fprintf(code, "lea %s, %s\n",
-            symbol_to_address(cg_context, expression->children),
-            register_name(expression->result_register));
+    symbol_address address = symbol_to_address(cg_context, expression->children);
+    switch (address.mode) {
+      case SYMBOL_ADDRESS_MODE_ERROR: return address.error;
+      case SYMBOL_ADDRESS_MODE_GLOBAL:
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
+                     REG_X86_64_RIP, address.global,
+                     expression->result_register);
+        break;
+      case SYMBOL_ADDRESS_MODE_LOCAL:
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, MEMORY_TO_REGISTER,
+                     REG_X86_64_RBP, address.local,
+                     expression->result_register);
+        break;
+    }
     // Offset memory address by index.
     if (offset) {
       femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
-                   offset, expression->result_register);
+          offset, expression->result_register);
     }
     break;
+  }
   case NODE_TYPE_IF:
     if (codegen_verbose) {
       fprintf(code, ";;#; If\n");
@@ -852,9 +1062,10 @@ Error codegen_expression_x86_64
     // Generate code using result register from condition expression.
     char *otherwise_label = label_generate();
     char *after_otherwise_label = label_generate();
-    const char *condition_register_name = register_name(expression->children->result_register);
-    fprintf(code, "test %s, %s\n", condition_register_name, condition_register_name);
-    fprintf(code, "jz %s\n", otherwise_label);
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_TEST, REGISTER_TO_REGISTER,
+                 expression->children->result_register,
+                 expression->children->result_register);
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_JCC, JUMP_TYPE_Z, otherwise_label);
     register_deallocate(cg_context, expression->children->result_register);
 
     if (codegen_verbose) {
@@ -894,7 +1105,7 @@ Error codegen_expression_x86_64
     femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                  last_expr->result_register, expression->result_register);
     register_deallocate(cg_context, last_expr->result_register);
-    fprintf(code, "jmp %s\n", after_otherwise_label);
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_JMP, NAME, after_otherwise_label);
 
     if (codegen_verbose) {
       fprintf(code, ";;#; If OTHERWISE\n");
@@ -1046,7 +1257,7 @@ Error codegen_expression_x86_64
 
       // Sign-extend the value in RAX to RDX. RDX is treated as the
       // 8 high bytes of a 16-byte number stored in RDX:RAX.
-      fprintf(code, "cqto\n");
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_CQO);
 
       // Call IDIV with right hand side of division operator.
       femit_x86_64(cg_context, INSTRUCTION_X86_64_IDIV,
@@ -1063,9 +1274,10 @@ Error codegen_expression_x86_64
                      REG_X86_64_RAX, expression->result_register);
       }
 
-      fprintf(code,
-              "pop %%rdx\n"
-              "pop %%rax\n");
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
+                   REGISTER, REG_X86_64_RDX);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
+                   REGISTER, REG_X86_64_RAX);
 
     } else if (strcmp(expression->value.symbol, "<<") == 0) {
       // Bitshift Left
@@ -1074,13 +1286,14 @@ Error codegen_expression_x86_64
       // Use left hand side result register as our result since SHL is destructive!
       expression->result_register = expression->children->result_register;
 
-      fprintf(code,
-              "push %%rcx\n"
-              "mov %s, %%rcx\n"
-              "sal %%cl, %s\n"
-              "pop %%rcx\n",
-              register_name(expression->children->next_child->result_register),
-              register_name(expression->children->result_register));
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
+                   REGISTER, REG_X86_64_RCX);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+                   expression->children->next_child->result_register, REG_X86_64_RCX);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_SAL, REGISTER,
+                   expression->children->result_register);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
+                   REGISTER, REG_X86_64_RCX);
 
       // Free no-longer-used right hand side result register.
       register_deallocate(cg_context, expression->children->next_child->result_register);
@@ -1091,13 +1304,14 @@ Error codegen_expression_x86_64
       // Use left hand side result register as our result since SHR is destructive!
       expression->result_register = expression->children->result_register;
 
-      fprintf(code,
-              "push %%rcx\n"
-              "mov %s, %%rcx\n"
-              "sar %%cl, %s\n"
-              "pop %%rcx\n",
-              register_name(expression->children->next_child->result_register),
-              register_name(expression->children->result_register));
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
+                   REGISTER, REG_X86_64_RCX);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+                   expression->children->next_child->result_register, REG_X86_64_RCX);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_SAR, REGISTER,
+                   expression->children->result_register);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
+                   REGISTER, REG_X86_64_RCX);
 
       // Free no-longer-used right hand side result register.
       register_deallocate(cg_context, expression->children->next_child->result_register);
@@ -1124,17 +1338,17 @@ Error codegen_expression_x86_64
     }
     if (!variable_residency) {
       // Global variable
-      fprintf(code, "mov %s(%%rip), %s\n",
-              expression->value.symbol,
-              register_name(expression->result_register));
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, NAME_TO_REGISTER,
+                   REG_X86_64_RIP, expression->value.symbol,
+                   expression->result_register);
     } else {
       // TODO: For each context change upwards (base pointer load), emit a call to load caller RBP
       // from current RBP into some register, and use that register as offset for memory access.
       // This will require us to differentiate scopes from stack frames, which is a problem for
       // another time :^). Good luck, future me!
-      fprintf(code, "mov %lld(%%rbp), %s\n",
-              tmpnode->value.integer,
-              register_name(expression->result_register));
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, MEMORY_TO_REGISTER,
+                   REG_X86_64_RBP, tmpnode->value.integer,
+                   expression->result_register);
     }
     break;
   case NODE_TYPE_VARIABLE_DECLARATION:
@@ -1167,7 +1381,8 @@ Error codegen_expression_x86_64
     // TODO: Optimize to subtract all local variable's stack size at
     // beginning of function rather than throughout.
     //   Subtract type size in bytes from stack pointer
-    fprintf(code, "sub $%lld, %%rsp\n", size_in_bytes);
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_SUB, IMMEDIATE_TO_REGISTER,
+                 size_in_bytes, REG_X86_64_RSP);
     // Keep track of RBP offset.
     cg_context->locals_offset -= size_in_bytes;
     //   Kept in codegen context.
@@ -1189,7 +1404,7 @@ Error codegen_expression_x86_64
       iterator = iterator->children;
     }
     if (!iterator) {
-      // TODO: Error here for invalid or mishapen AST.
+      // TODO: Error here for invalid or misshapen AST.
     }
 
     // Codegen RHS
@@ -1197,37 +1412,33 @@ Error codegen_expression_x86_64
                                     expression->children->next_child);
     if (err.type) { break; }
 
-    // When non-zero, de-allocate LHS register and free result string.
-    char should_free_result = 0;
-
-    // Set `result` to operand representing LHS that will be written into.
     if (expression->children->type == NODE_TYPE_VARIABLE_ACCESS) {
-      result = symbol_to_address(cg_context, expression->children);
+      symbol_address address = symbol_to_address(cg_context, expression->children);
+      switch (address.mode) {
+        case SYMBOL_ADDRESS_MODE_ERROR: return address.error;
+        case SYMBOL_ADDRESS_MODE_GLOBAL:
+          femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_NAME,
+                       expression->children->next_child->result_register,
+                       REG_X86_64_RIP, address.global);
+          break;
+        case SYMBOL_ADDRESS_MODE_LOCAL:
+          femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_MEMORY,
+                       expression->children->next_child->result_register,
+                       REG_X86_64_RBP, address.local);
+          break;
+      }
     } else {
-      should_free_result = 1;
       // Codegen LHS
       err = codegen_expression_x86_64(cg_context, context, next_child_context,
                                       expression->children);
       if (err.type) { break; }
-      const char *name = register_name(expression->children->result_register);
-      // Put parenthesis around `result`.
-      size_t needed_len = strlen(name) + 2;
-      char *result_copy = strdup(name);
-      result = malloc(needed_len + 1);
-      snprintf(result, needed_len + 1, "(%s)", result_copy);
-      result[needed_len] = '\0';
-      free(result_copy);
-    }
-    fprintf(code, "mov %s, %s\n",
-            register_name( expression->children->next_child->result_register),
-            result);
-    register_deallocate(cg_context, expression->children->next_child->result_register);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_MEMORY,
+                   expression->children->next_child->result_register,
+                   expression->children->result_register, 0);
 
-    if (should_free_result) {
-      free(result);
+      register_deallocate(cg_context, expression->children->next_child->result_register);
       register_deallocate(cg_context, expression->children->result_register);
     }
-
     break;
   }
 
@@ -1238,13 +1449,23 @@ Error codegen_expression_x86_64
   return err;
 }
 
-const char *function_header_x86_64 =
-  "push %rbp\n"
-  "mov %rsp, %rbp\n"
-  "sub $32, %rsp\n";
-const char *function_footer_x86_64 =
-  "pop %rbp\n"
-  "ret\n";
+void emit_function_header_x86_64(CodegenContext *cg_context) {
+  femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH, REGISTER,
+               REG_X86_64_RBP);
+  femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+               REG_X86_64_RSP, REG_X86_64_RBP);
+  femit_x86_64(cg_context, INSTRUCTION_X86_64_SUB, IMMEDIATE_TO_REGISTER,
+               32, REG_X86_64_RSP);
+}
+
+void emit_function_footer_x86_64(CodegenContext *cg_context) {
+  femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+               REG_X86_64_RBP, REG_X86_64_RSP);
+  femit_x86_64(cg_context, INSTRUCTION_X86_64_POP, REGISTER,
+               REG_X86_64_RBP);
+  femit_x86_64(cg_context, INSTRUCTION_X86_64_RET);
+}
+
 Error codegen_function_x86_64_gas
 (CodegenContext *cg_context,
  ParsingContext *context,
@@ -1273,12 +1494,17 @@ Error codegen_function_x86_64_gas
   }
 
   // Nested function execution protection
-  fprintf(code, "jmp after%s\n", name);
+  char after_name_buffer[1024] = {0};
+  snprintf(after_name_buffer, 1024, "after%s", name);
+  after_name_buffer[sizeof after_name_buffer - 1] = 0;
+  femit_x86_64(cg_context, INSTRUCTION_X86_64_JMP, NAME,
+               after_name_buffer);
+
   // Function beginning label
   fprintf(code, "%s:\n", name);
 
   // Function header
-  fprintf(code, "%s", function_header_x86_64);
+  emit_function_header_x86_64(cg_context);
 
   // Function body
   ParsingContext *ctx = context;
@@ -1307,19 +1533,17 @@ Error codegen_function_x86_64_gas
   }
 
   // Copy last expression result register to RAX
+  // femit() will optimise the move away if the result is already in RAX.
   if (last_expression) {
-    if (last_expression->result_register != REG_X86_64_RAX) {
-      const char *name = register_name(last_expression->result_register);
-      fprintf(code, "mov %s, %%rax\n", name);
-    }
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+                 last_expression->result_register, REG_X86_64_RAX);
   }
 
   // Function footer
-  fprintf(code, "add $%lld, %%rsp\n", -cg_context->locals_offset);
-  fprintf(code, "%s", function_footer_x86_64);
+  emit_function_footer_x86_64(cg_context);
 
   // Nested function execution jump label
-  fprintf(code, "after%s:\n", name);
+  fprintf(code, "%s:\n", after_name_buffer);
   // after<function_label>:
 
   // Free context;
@@ -1357,8 +1581,8 @@ Error codegen_program_x86_64(CodegenContext *cg_context, ParsingContext *context
   fprintf(code,
           ".section .text\n"
           ".global main\n"
-          "main:\n"
-          "%s", function_header_x86_64);
+          "main:\n");
+  emit_function_header_x86_64(cg_context);
 
   ParsingContext *next_child_context = context->children;
   Node *last_expression = program->children;
@@ -1376,13 +1600,13 @@ Error codegen_program_x86_64(CodegenContext *cg_context, ParsingContext *context
   }
 
   // Copy last expression into RAX register for return value.
-  if (last_expression->result_register != REG_X86_64_RAX) {
-    const char *name = register_name(last_expression->result_register);
-    fprintf(code, "mov %s, %%rax\n", name);
+  // femit() will optimise the move away if the result is already in RAX.
+  if (last_expression) {
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        last_expression->result_register, REG_X86_64_RAX);
   }
 
-  fprintf(code, "add $%lld, %%rsp\n", -cg_context->locals_offset);
-  fprintf(code, "%s", function_footer_x86_64);
+  emit_function_footer_x86_64(cg_context);
 
   return err;
 }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -179,32 +179,8 @@ Error codegen_expression
       // TODO: Only save scratch registers that are in-use.
 
       // Put arguments in RCX, RDX, R8, R9, then on the stack in reverse order.
-      if (iterator) {
+      while (iterator) {
         // Place first argument in RCX or XMM0
-        err = codegen_expression(cg_context, context, next_child_context, iterator);
-        if (err.type) { return err; }
-
-        codegen_add_external_function_arg(cg_context, iterator->result_register);
-        iterator = iterator->next_child;
-      }
-      if (iterator) {
-        // Place second argument in RDX or XMM1
-        err = codegen_expression(cg_context, context, next_child_context, iterator);
-        if (err.type) { return err; }
-
-        codegen_add_external_function_arg(cg_context, iterator->result_register);
-        iterator = iterator->next_child;
-      }
-      if (iterator) {
-        // Place third argument in R8 or XMM2
-        err = codegen_expression(cg_context, context, next_child_context, iterator);
-        if (err.type) { return err; }
-
-        codegen_add_external_function_arg(cg_context, iterator->result_register);
-        iterator = iterator->next_child;
-      }
-      if (iterator) {
-        // Place third argument in R9 or XMM3
         err = codegen_expression(cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -109,28 +109,28 @@ const char *instruction_mnemonic_x86_64(enum CodegenOutputFormat fmt, enum Instr
   return NULL; // Unreachable
 }
 
-void femit_x86_64_imm_to_reg(FILE *code, CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_imm_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
   int64_t immediate                    = va_arg(args, int64_t);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
 
   const char *destination = register_name(context, destination_register);
 
-  fprintf(code, "%s $%" PRId64 ", %s\n",
+  fprintf(context->code, "%s $%" PRId64 ", %s\n",
           mnemonic, immediate, destination);
 }
 
-void femit_x86_64_imm_to_mem(FILE *code, CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_imm_to_mem(CodegenContext *context, const char *mnemonic, va_list args) {
   int64_t immediate                    = va_arg(args, int64_t);
   RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
   int64_t offset                       = va_arg(args, int64_t);
 
   const char *address = register_name(context, address_register);
 
-  fprintf(code, "%s $%" PRId64 ", %" PRId64 "(%s)\n",
+  fprintf(context->code, "%s $%" PRId64 ", %" PRId64 "(%s)\n",
           mnemonic, immediate, offset, address);
 }
 
-void femit_x86_64_mem_to_reg(FILE *code, CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_mem_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
   int64_t offset                           = va_arg(args, int64_t);
   RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
@@ -138,12 +138,12 @@ void femit_x86_64_mem_to_reg(FILE *code, CodegenContext *context, const char *mn
   const char *address = register_name(context, address_register);
   const char *destination = register_name(context, destination_register);
 
-  fprintf(code,
+  fprintf(context->code,
           "%s %" PRId64 "(%s), %s\n",
           mnemonic, offset, address, destination);
 }
 
-void femit_x86_64_name_to_reg(FILE *code, CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_name_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
   char *name                               = va_arg(args, char *);
   RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
@@ -151,12 +151,12 @@ void femit_x86_64_name_to_reg(FILE *code, CodegenContext *context, const char *m
   const char *address = register_name(context, address_register);
   const char *destination = register_name(context, destination_register);
 
-  fprintf(code,
+  fprintf(context->code,
           "%s %s(%s), %s\n",
           mnemonic, name, address, destination);
 }
 
-void femit_x86_64_reg_to_mem(FILE *code, CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_reg_to_mem(CodegenContext *context, const char *mnemonic, va_list args) {
   RegisterDescriptor source_register   = va_arg(args, RegisterDescriptor);
   RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
   int64_t offset                       = va_arg(args, int64_t);
@@ -164,27 +164,26 @@ void femit_x86_64_reg_to_mem(FILE *code, CodegenContext *context, const char *mn
   const char *source = register_name(context, source_register);
   const char *address = register_name(context, address_register);
 
-  fprintf(code,
+  fprintf(context->code,
           "%s %s, %" PRId64 "(%s)\n",
           mnemonic, source, offset, address);
 }
 
-void femit_x86_64_reg_to_reg(FILE *code, CodegenContext *context, const char *mnemonic, va_list args) {
+void femit_x86_64_reg_to_reg(CodegenContext *context, const char *mnemonic, va_list args) {
   RegisterDescriptor source_register       = va_arg(args, RegisterDescriptor);
   RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
 
   const char *source = register_name(context, source_register);
   const char *destination = register_name(context, destination_register);
 
-  fprintf(code,
+  fprintf(context->code,
           "%s %s, %s\n",
           mnemonic, source, destination);
 }
 
 
 void femit_x86_64
-(FILE *code,
- CodegenContext *context,
+(CodegenContext *context,
  enum Instructions_x86_64 instruction,
  ...
  )
@@ -212,23 +211,23 @@ void femit_x86_64
         panic("Unhandled operand type in x86_64 GAS code generation for MOV.");
       case IMMEDIATE_TO_REGISTER:
         // femit(..., IMMEDIATE_TO_REGISTER, (int64_t)immediate value, (RegisterDescriptor) destination)
-        femit_x86_64_imm_to_reg(code, context, mnemonic, args);
+        femit_x86_64_imm_to_reg(context, mnemonic, args);
         break;
       case IMMEDIATE_TO_MEMORY:
         // femit(..., IMMEDIATE_TO_MEMORY, (int64_t)immediate value, (RegisterDescriptor) memory_address, (int64_t) memory_offset)
-        femit_x86_64_imm_to_mem(code, context, mnemonic, args);
+        femit_x86_64_imm_to_mem(context, mnemonic, args);
         break;
       case MEMORY_TO_REGISTER:
         // femit(..., MEMORY_TO_REGISTER, (int64_t)memory_offset, (RegisterDescriptor) memory_address, (RegisterDescriptor) destination)
-        femit_x86_64_mem_to_reg(code, context, mnemonic, args);
+        femit_x86_64_mem_to_reg(context, mnemonic, args);
         break;
       case REGISTER_TO_MEMORY:
         // femit(..., REGISTER_TO_MEMORY, (RegisterDescriptor) source, (RegisterDescriptor) address, (int64_t) memory_offset)
-        femit_x86_64_reg_to_mem(code, context, mnemonic, args);
+        femit_x86_64_reg_to_mem(context, mnemonic, args);
         break;
       case REGISTER_TO_REGISTER:
         // femit(..., REGISTER_TO_REGISTER, (RegisterDescriptor) source, (RegisterDescriptor) destination)
-        femit_x86_64_reg_to_reg(code, context, mnemonic, args);
+        femit_x86_64_reg_to_reg(context, mnemonic, args);
         break;
       }
       break;
@@ -240,11 +239,11 @@ void femit_x86_64
         panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or NAME_TO_REGISTER operand type with LEA instruction.");
       case MEMORY_TO_REGISTER:
         // femit(..., MEMORY_TO_REGISTER, (int64_t) memory_offset, (RegisterDescriptor) memory_address, (RegisterDescriptor) destination)
-        femit_x86_64_mem_to_reg(code, context, mnemonic, args);
+        femit_x86_64_mem_to_reg(context, mnemonic, args);
         break;
       case NAME_TO_REGISTER:
         // femit(..., MEMORY_TO_REGISTER, (char *) name, (RegisterDescriptor) memory_address, (RegisterDescriptor) destination)
-        femit_x86_64_name_to_reg(code, context, mnemonic, args);
+        femit_x86_64_name_to_reg(context, mnemonic, args);
         break;
       }
       break;
@@ -256,10 +255,10 @@ void femit_x86_64
         panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or REGISTER_TO_REGISTER operand type with IMUL instruction.");
         break;
       case MEMORY_TO_REGISTER:
-        femit_x86_64_mem_to_reg(code, context, mnemonic, args);
+        femit_x86_64_mem_to_reg(context, mnemonic, args);
         break;
       case REGISTER_TO_REGISTER:
-        femit_x86_64_reg_to_reg(code, context, mnemonic, args);
+        femit_x86_64_reg_to_reg(context, mnemonic, args);
         break;
       }
       break;
@@ -277,7 +276,7 @@ void femit_x86_64
 
         const char *destination = register_name(context, destination_register);
 
-        fprintf(code, "%s %" PRId64 "(%s)\n",
+        fprintf(context->code, "%s %" PRId64 "(%s)\n",
                 mnemonic, offset, destination);
         break;
       }
@@ -287,7 +286,7 @@ void femit_x86_64
 
         const char *source = register_name(context, source_register);
 
-        fprintf(code, "%s %s\n",
+        fprintf(context->code, "%s %s\n",
                 mnemonic, source);
         break;
       }
@@ -302,13 +301,13 @@ void femit_x86_64
 
         const char *call_address = register_name(context, call_register);
 
-        fprintf(code, "%s *%s\n",
+        fprintf(context->code, "%s *%s\n",
                 mnemonic, call_address);
 
       } else if (operand == NAME) {
         char *name = va_arg(args, char *);
 
-        fprintf(code, "%s %s\n",
+        fprintf(context->code, "%s %s\n",
                 mnemonic, name);
 
       } else {
@@ -325,7 +324,7 @@ void femit_x86_64
 
         const char *value = register_name(context, value_register);
 
-        fprintf(code, "%s %s\n",
+        fprintf(context->code, "%s %s\n",
                 mnemonic, value);
       } else if (operand == MEMORY) {
         // femit(..., MEMORY, (RegisterDescriptor) memory_address, (int64_t) memory_offset)
@@ -334,14 +333,14 @@ void femit_x86_64
 
         const char *address = register_name(context, address_register);
 
-        fprintf(code, "%s %" PRId64 "(%s)",
+        fprintf(context->code, "%s %" PRId64 "(%s)",
                 mnemonic, offset, address);
 
       } else if (operand == IMMEDIATE) {
         // femit(..., IMMEDIATE, (int64_t) immediate)
         int64_t immediate = va_arg(args, RegisterDescriptor);
 
-        fprintf(code, "%s $%" PRId64 "\n",
+        fprintf(context->code, "%s $%" PRId64 "\n",
                 mnemonic, immediate);
 
       } else {
@@ -407,6 +406,7 @@ CodegenContext *codegen_context_x86_64_gas_mswin_create(CodegenContext *parent) 
   }
 
   CodegenContext *cg_ctx = calloc(1,sizeof(CodegenContext));
+  if (parent) cg_ctx->code = parent->code;
   cg_ctx->parent = parent;
   cg_ctx->locals = environment_create(NULL);
   cg_ctx->locals_offset = -32;
@@ -701,9 +701,10 @@ const char *comparison_suffixes_x86_64[COMPARE_COUNT] = {
 void codegen_comparison_x86_64
 (CodegenContext *cg_context,
  Node *expression,
- enum ComparisonType type,
- FILE *code) {
+ enum ComparisonType type) {
   ASSERT(type < COMPARE_COUNT, "Invalid comparison type");
+
+  FILE *code = cg_context->code;
 
   expression->result_register = register_allocate(cg_context);
 
@@ -731,12 +732,10 @@ Error codegen_function_x86_64_gas
  ParsingContext *context,
  ParsingContext **next_child_context,
  char *name,
- Node *function,
- FILE *code);
+ Node *function);
 
 Error codegen_expression_x86_64
-(FILE *code,
- CodegenContext *cg_context,
+(CodegenContext *cg_context,
  ParsingContext *context,
  ParsingContext **next_child_context,
  Node *expression
@@ -746,6 +745,7 @@ Error codegen_expression_x86_64
   char *result = NULL;
   Node *tmpnode = node_allocate();
   Node *iterator = NULL;
+  FILE *code = cg_context->code;
   long long count = 0;
 
   ParsingContext *original_context = context;
@@ -760,7 +760,7 @@ Error codegen_expression_x86_64
       fprintf(code, ";;#; INTEGER: %lld\n", expression->value.integer);
     }
     expression->result_register = register_allocate(cg_context);
-    femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV,
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV,
                  IMMEDIATE_TO_REGISTER,
                  (int64_t)expression->value.integer,
                  expression->result_register);
@@ -772,7 +772,7 @@ Error codegen_expression_x86_64
 
     // TODO: Should we technically save all in-use scratch registers?
     // Save RAX because function call will over-write it!
-    femit_x86_64(code, cg_context, INSTRUCTION_X86_64_PUSH, REGISTER, REG_X86_64_RAX);
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH, REGISTER, REG_X86_64_RAX);
 
     // Setup function environment based on calling convention.
 
@@ -791,78 +791,78 @@ Error codegen_expression_x86_64
       if (iterator) {
         // Place first argument in RCX or XMM0
         err = codegen_expression_x86_64
-          (code, cg_context, context, next_child_context, iterator);
+          (cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
         // Ensure iterator result register is moved into RCX.
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                      iterator->result_register, REG_X86_64_RCX);
         iterator = iterator->next_child;
       }
       if (iterator) {
         // Place second argument in RDX or XMM1
         err = codegen_expression_x86_64
-          (code, cg_context, context, next_child_context, iterator);
+          (cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                      iterator->result_register, REG_X86_64_RDX);
         iterator = iterator->next_child;
       }
       if (iterator) {
         // Place third argument in R8 or XMM2
         err = codegen_expression_x86_64
-          (code, cg_context, context, next_child_context, iterator);
+          (cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                      iterator->result_register, REG_X86_64_R8);
         iterator = iterator->next_child;
       }
       if (iterator) {
         // Place third argument in R9 or XMM3
         err = codegen_expression_x86_64
-          (code, cg_context, context, next_child_context, iterator);
+          (cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                      iterator->result_register, REG_X86_64_R9);
         iterator = iterator->next_child;
       }
 
       // TODO: Reverse rest of arguments, push on stack.
 
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_CALL, NAME, expression->children->value.symbol);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_CALL, NAME, expression->children->value.symbol);
 
     } else {
       // Push arguments on stack in order.
       while (iterator) {
         err = codegen_expression_x86_64
-          (code, cg_context, context, next_child_context, iterator);
+          (cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_PUSH, REGISTER, iterator->result_register);
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH, REGISTER, iterator->result_register);
         register_deallocate(cg_context, iterator->result_register);
         iterator = iterator->next_child;
         count += 8;
       }
 
-      err = codegen_expression_x86_64(code, cg_context, context, next_child_context, expression->children);
+      err = codegen_expression_x86_64(cg_context, context, next_child_context, expression->children);
       if (err.type) { return err; }
 
       // Emit call
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_CALL, REGISTER, expression->children->result_register);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_CALL, REGISTER, expression->children->result_register);
       register_deallocate(cg_context, expression->children->result_register);
     }
 
     if (count) {
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER, count, REG_X86_64_RSP);
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER, count, REG_X86_64_RSP);
     }
 
     // Copy return value of function call from RAX to result register
     expression->result_register = register_allocate(cg_context);
     if (expression->result_register != REG_X86_64_RAX) {
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                    REG_X86_64_RAX, expression->result_register);
       // Save overwritten in-use registers.
       fprintf(code, "pop %%rax\n");
     } else {
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
                    (int64_t)8, REG_X86_64_RSP);
     }
 
@@ -888,20 +888,20 @@ Error codegen_expression_x86_64
     }
     err = codegen_function_x86_64_gas(cg_context,
                                       context, next_child_context,
-                                      result, expression, code);
+                                      result, expression);
 
     // Function returns beginning of instructions address.
     expression->result_register = register_allocate(cg_context);
-    femit_x86_64(code, cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
                  result, REG_X86_64_RIP, expression->result_register);
     break;
   case NODE_TYPE_DEREFERENCE:
     if (codegen_verbose) {
       fprintf(code, ";;#; Dereference\n");
     }
-    err = codegen_expression_x86_64(code, cg_context,
-                                          context, next_child_context,
-                                          expression->children);
+    err = codegen_expression_x86_64(cg_context,
+                                    context, next_child_context,
+                                    expression->children);
     if (err.type) { return err; }
     expression->result_register = expression->children->result_register;
     break;
@@ -939,7 +939,7 @@ Error codegen_expression_x86_64
             register_name(cg_context, expression->result_register));
     // Offset memory address by index.
     if (offset) {
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
                    offset, expression->result_register);
     }
     break;
@@ -949,9 +949,9 @@ Error codegen_expression_x86_64
     }
 
     // Generate if condition expression code.
-    err = codegen_expression_x86_64(code, cg_context,
-                                          context, next_child_context,
-                                          expression->children);
+    err = codegen_expression_x86_64(cg_context,
+                                    context, next_child_context,
+                                    expression->children);
     if (err.type) { return err; }
 
     if (codegen_verbose) {
@@ -987,9 +987,9 @@ Error codegen_expression_x86_64
     Node *last_expr = NULL;
     Node *expr = expression->children->next_child->children;
     while (expr) {
-      err = codegen_expression_x86_64(code, cg_context,
-                                            ctx, &next_child_ctx,
-                                            expr);
+      err = codegen_expression_x86_64(cg_context,
+                                      ctx, &next_child_ctx,
+                                      expr);
       if (err.type) { return err; }
       if (last_expr) {
         register_deallocate(cg_context, last_expr->result_register);
@@ -1000,7 +1000,7 @@ Error codegen_expression_x86_64
 
     // Generate code to copy last expr result register to if result register.
     expression->result_register = register_allocate(cg_context);
-    femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                  last_expr->result_register, expression->result_register);
     register_deallocate(cg_context, last_expr->result_register);
     fprintf(code, "jmp %s\n", after_otherwise_label);
@@ -1030,9 +1030,9 @@ Error codegen_expression_x86_64
 
       expr = expression->children->next_child->next_child->children;
       while (expr) {
-        err = codegen_expression_x86_64(code, cg_context,
-                                              ctx, &next_child_ctx,
-                                              expr);
+        err = codegen_expression_x86_64(cg_context,
+                                        ctx, &next_child_ctx,
+                                        expr);
         if (err.type) { return err; }
         if (last_expr) {
           register_deallocate(cg_context, last_expr->result_register);
@@ -1042,12 +1042,12 @@ Error codegen_expression_x86_64
       }
       // Copy last_expr result register to if result register.
       if (last_expr) {
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                      last_expr->result_register, expression->result_register);
         register_deallocate(cg_context, last_expr->result_register);
       }
     } else {
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, IMMEDIATE_TO_REGISTER,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, IMMEDIATE_TO_REGISTER,
                    (int64_t)0, expression->result_register);
     }
 
@@ -1065,21 +1065,21 @@ Error codegen_expression_x86_64
     //printf("Codegenning binary operator %s\n", expression->value.symbol);
     //print_node(tmpnode,0);
 
-    err = codegen_expression_x86_64(code, cg_context,
-                                          context, next_child_context,
-                                          expression->children);
+    err = codegen_expression_x86_64(cg_context,
+                                    context, next_child_context,
+                                    expression->children);
     if (err.type) { return err; }
-    err = codegen_expression_x86_64(code, cg_context,
-                                          context, next_child_context,
-                                          expression->children->next_child);
+    err = codegen_expression_x86_64(cg_context,
+                                    context, next_child_context,
+                                    expression->children->next_child);
     if (err.type) { return err; }
 
     if (strcmp(expression->value.symbol, ">") == 0) {
-      codegen_comparison_x86_64(cg_context, expression, COMPARE_GT, code);
+      codegen_comparison_x86_64(cg_context, expression, COMPARE_GT);
     } else if (strcmp(expression->value.symbol, "<") == 0) {
-      codegen_comparison_x86_64(cg_context, expression, COMPARE_LT, code);
+      codegen_comparison_x86_64(cg_context, expression, COMPARE_LT);
     } else if (strcmp(expression->value.symbol, "=") == 0) {
-      codegen_comparison_x86_64(cg_context, expression, COMPARE_EQ, code);
+      codegen_comparison_x86_64(cg_context, expression, COMPARE_EQ);
     } else if (strcmp(expression->value.symbol, "+") == 0) {
       // Plus/Addition
       // https://www.felixcloutier.com/x86/add
@@ -1088,7 +1088,7 @@ Error codegen_expression_x86_64
       expression->result_register = expression->children->next_child->result_register;
 
       femit_x86_64
-        (code, cg_context,
+        (cg_context,
          INSTRUCTION_X86_64_ADD,
          expression->children->result_register,
          expression->children->next_child->result_register);
@@ -1102,7 +1102,7 @@ Error codegen_expression_x86_64
       // Use right hand side result register as our result since SUB is destructive!
       expression->result_register = expression->children->result_register;
 
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_SUB, REGISTER_TO_REGISTER,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_SUB, REGISTER_TO_REGISTER,
                    expression->children->next_child->result_register,
                    expression->children->result_register);
 
@@ -1116,7 +1116,7 @@ Error codegen_expression_x86_64
       // Use right hand side result register as our result since ADD is destructive!
       expression->result_register = expression->children->next_child->result_register;
 
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_IMUL, REGISTER_TO_REGISTER,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_IMUL, REGISTER_TO_REGISTER,
                    expression->children->result_register,
                    expression->children->next_child->result_register);
 
@@ -1142,13 +1142,13 @@ Error codegen_expression_x86_64
       // result register is RAX, in which case we can use it
       // destructively as our division expression result register.
 
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_PUSH,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
                    REGISTER, REG_X86_64_RAX);
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_PUSH,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
                    REGISTER, REG_X86_64_RDX);
 
       // Load RAX with left hand side of division operator, if needed.
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                    expression->children->result_register, REG_X86_64_RAX);
 
 
@@ -1158,17 +1158,17 @@ Error codegen_expression_x86_64
       fprintf(code, "cqto\n");
 
       // Call IDIV with right hand side of division operator.
-      femit_x86_64(code, cg_context, INSTRUCTION_X86_64_IDIV,
+      femit_x86_64(cg_context, INSTRUCTION_X86_64_IDIV,
                    REGISTER, expression->children->next_child->result_register);
 
       expression->result_register = register_allocate(cg_context);
       if (modulo_flag) {
         // Move return value from RDX into wherever it actually belongs.
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                      REG_X86_64_RDX, expression->result_register);
       } else {
         // Move return value from RAX into wherever it actually belongs.
-        femit_x86_64(code, cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
+        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
                      REG_X86_64_RAX, expression->result_register);
       }
 
@@ -1302,8 +1302,8 @@ Error codegen_expression_x86_64
     }
 
     // Codegen RHS
-    err = codegen_expression_x86_64(code, cg_context, context, next_child_context,
-                                          expression->children->next_child);
+    err = codegen_expression_x86_64(cg_context, context, next_child_context,
+                                    expression->children->next_child);
     if (err.type) { break; }
 
     // When non-zero, de-allocate LHS register and free result string.
@@ -1315,8 +1315,8 @@ Error codegen_expression_x86_64
     } else {
       should_free_result = 1;
       // Codegen LHS
-      err = codegen_expression_x86_64(code, cg_context, context, next_child_context,
-                                            expression->children);
+      err = codegen_expression_x86_64(cg_context, context, next_child_context,
+                                      expression->children);
       if (err.type) { break; }
       const char *name = register_name(cg_context, expression->children->result_register);
       // Put parenthesis around `result`.
@@ -1359,11 +1359,11 @@ Error codegen_function_x86_64_gas
  ParsingContext *context,
  ParsingContext **next_child_context,
  char *name,
- Node *function,
- FILE *code
+ Node *function
  )
 {
   Error err = ok;
+  FILE *code = cg_context->code;
 
   cg_context = create_codegen_context(cg_context);
 
@@ -1405,7 +1405,7 @@ Error codegen_function_x86_64_gas
   Node *last_expression = NULL;
   Node *expression = function->children->next_child->next_child->children;
   while (expression) {
-    err = codegen_expression_x86_64(code, cg_context, ctx, &next_child_ctx, expression);
+    err = codegen_expression_x86_64(cg_context, ctx, &next_child_ctx, expression);
     register_deallocate(cg_context, expression->result_register);
     if (err.type) {
       print_error(err);
@@ -1436,8 +1436,9 @@ Error codegen_function_x86_64_gas
   return ok;
 }
 
-Error codegen_program_x86_64(FILE *code, CodegenContext *cg_context, ParsingContext *context, Node *program) {
+Error codegen_program_x86_64(CodegenContext *cg_context, ParsingContext *context, Node *program) {
   Error err = ok;
+  FILE *code = cg_context->code;
 
   fprintf(code, "%s", ".section .data\n");
 
@@ -1476,7 +1477,7 @@ Error codegen_program_x86_64(FILE *code, CodegenContext *cg_context, ParsingCont
       expression = expression->next_child;
       continue;
     }
-    err = codegen_expression_x86_64(code, cg_context, context, &next_child_context, expression);
+    err = codegen_expression_x86_64(cg_context, context, &next_child_context, expression);
     if (err.type) { return err; }
     register_deallocate(cg_context, expression->result_register);
     last_expression = expression;
@@ -1522,6 +1523,7 @@ Error codegen_program
     CodegenContext *cg_context;
     if (call_convention == CG_CALL_CONV_MSWIN) {
       cg_context = codegen_context_x86_64_gas_mswin_create(NULL);
+      cg_context->code = code;
     } else if (call_convention == CG_CALL_CONV_LINUX) {
       // TODO: Create codegen context for GAS linux assembly.
       ERROR_PREP(err, ERROR_TODO, "Create codegen context for GAS linux x86_64 assembly.");
@@ -1530,7 +1532,7 @@ Error codegen_program
       ERROR_PREP(err, ERROR_GENERIC, "Unrecognized calling convention!");
       return err;
     }
-    err = codegen_program_x86_64(code, cg_context, context, program);
+    err = codegen_program_x86_64(cg_context, context, program);
     codegen_context_x86_64_mswin_free(cg_context);
   } else {
     printf("ERROR: Unrecognized codegen format\n");

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1,5 +1,5 @@
 #include <codegen.h>
-#include "codegen/codegen_platforms.h"
+#include <codegen/codegen_platforms.h>
 
 #include <environment.h>
 #include <error.h>

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1,4 +1,5 @@
 #include <codegen.h>
+#include "codegen/codegen_platforms.h"
 
 #include <environment.h>
 #include <error.h>
@@ -13,657 +14,7 @@
 #include <typechecker.h>
 
 char codegen_verbose = 1;
-
-/// This is used for defining lookup tables etc. and
-/// ensures that the registers are always in the correct
-/// order
-#define FOR_ALL_X86_64_REGISTERS(F)     \
-  F(RAX, "rax", "eax", "ax", "al")      \
-  F(RBX, "rbx", "ebx", "bx", "bl")      \
-  F(RCX, "rcx", "ecx", "cx", "cl")      \
-  F(RDX, "rdx", "edx", "dx", "dl")      \
-  F(R8,  "r8", "r8d", "r8w", "r8b")     \
-  F(R9,  "r9", "r9d", "r9w", "r9b")     \
-  F(R10, "r10", "r10d", "r10w", "r10b") \
-  F(R11, "r11", "r11d", "r11w", "r11b") \
-  F(R12, "r12", "r12d", "r12w", "r12b") \
-  F(R13, "r13", "r13d", "r13w", "r13b") \
-  F(R14, "r14", "r14d", "r14w", "r14b") \
-  F(R15, "r15", "r15d", "r15w", "r15b") \
-  F(RSI, "rsi", "esi", "si", "sil")     \
-  F(RDI, "rdi", "edi", "di", "dil")     \
-  F(RBP, "rbp", "ebp", "bp", "bpl")     \
-  F(RSP, "rsp", "esp", "sp", "spl")     \
-  F(RIP, "rip", "eip", "ip", "ipl")
-
-#define DEFINE_REGISTER_ENUM(name, ...) REG_X86_64_##name,
-#define REGISTER_NAME_64(ident, name, ...) name,
-#define REGISTER_NAME_32(ident, name, name_32, ...) name_32,
-#define REGISTER_NAME_16(ident, name, name_32, name_16, ...) name_16,
-#define REGISTER_NAME_8(ident, name, name_32, name_16, name_8, ...) name_8,
-
-/// Used when initializing Register arrays for RegisterPool.
-#define INIT_REGISTER(ident, ...)  \
-  ((registers)[REG_X86_64_##ident] = (Register){.in_use = 0, .descriptor = (REG_X86_64_##ident)});
-
-/// Lookup tables for register names.
-#define DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(name, bits)                                        \
-  const char *name(RegisterDescriptor descriptor) {                                             \
-    static const char* register_names[] = { FOR_ALL_X86_64_REGISTERS(REGISTER_NAME_##bits) };   \
-    if (descriptor < 0 || descriptor >= REG_X86_64_COUNT) {                                     \
-      panic("ERROR::" #name "(): Could not find register with descriptor of %d\n", descriptor); \
-    }                                                                                           \
-    return register_names[descriptor];                                                          \
-  }
-
-enum Registers_x86_64 {
-  FOR_ALL_X86_64_REGISTERS(DEFINE_REGISTER_ENUM)
-  REG_X86_64_COUNT
-};
-
-/// Define register_name and friends.
-DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name, 64)
-DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name_32, 32)
-DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name_16, 16)
-DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name_8, 8)
-
-#undef REGISTER_NAME_64
-#undef REGISTER_NAME_32
-#undef REGISTER_NAME_16
-#undef REGISTER_NAME_8
-
-#undef DEFINE_REGISTER_ENUM
-#undef DEFINE_REGISTER_NAME_LOOKUP_FUNCTION
-
-/// Types of conditional jump instructions (Jcc).
-/// Do NOT reorder these.
-enum IndirectJumpType_x86_64 {
-  JUMP_TYPE_A,
-  JUMP_TYPE_AE,
-  JUMP_TYPE_B,
-  JUMP_TYPE_BE,
-  JUMP_TYPE_C,
-  JUMP_TYPE_E,
-  JUMP_TYPE_Z,
-  JUMP_TYPE_G,
-  JUMP_TYPE_GE,
-  JUMP_TYPE_L,
-  JUMP_TYPE_LE,
-  JUMP_TYPE_NA,
-  JUMP_TYPE_NAE,
-  JUMP_TYPE_NB,
-  JUMP_TYPE_NBE,
-  JUMP_TYPE_NC,
-  JUMP_TYPE_NE,
-  JUMP_TYPE_NG,
-  JUMP_TYPE_NGE,
-  JUMP_TYPE_NL,
-  JUMP_TYPE_NLE,
-  JUMP_TYPE_NO,
-  JUMP_TYPE_NP,
-  JUMP_TYPE_NS,
-  JUMP_TYPE_NZ,
-  JUMP_TYPE_O,
-  JUMP_TYPE_P,
-  JUMP_TYPE_PE,
-  JUMP_TYPE_PO,
-  JUMP_TYPE_S,
-
-  JUMP_TYPE_COUNT,
-};
-
-/// Do NOT reorder these.
-static const char *jump_type_names_x86_64[] = {
-  "a",
-  "ae",
-  "b",
-  "be",
-  "c",
-  "e",
-  "z",
-  "g",
-  "ge",
-  "l",
-  "le",
-  "na",
-  "nae",
-  "nb",
-  "nbe",
-  "nc",
-  "ne",
-  "ng",
-  "nge",
-  "nl",
-  "nle",
-  "no",
-  "np",
-  "ns",
-  "nz",
-  "o",
-  "p",
-  "pe",
-  "po",
-  "s",
-};
-
-// TODO: All instructions we use in x86_64 should be in this enum.
-enum Instructions_x86_64 {
-  /// Arithmetic instructions.
-  INSTRUCTION_X86_64_ADD,
-  INSTRUCTION_X86_64_SUB,
-  // INSTRUCTION_X86_64_MUL,
-  INSTRUCTION_X86_64_IMUL,
-  // INSTRUCTION_X86_64_DIV,
-  INSTRUCTION_X86_64_IDIV,
-  INSTRUCTION_X86_64_XOR,
-  INSTRUCTION_X86_64_CMP,
-  INSTRUCTION_X86_64_TEST,
-  INSTRUCTION_X86_64_CQO,
-  INSTRUCTION_X86_64_SETCC,
-  INSTRUCTION_X86_64_SAL, ///< RegisterDescriptor reg | Immediate imm, RegisterDescriptor reg
-  INSTRUCTION_X86_64_SHL = INSTRUCTION_X86_64_SAL,
-  INSTRUCTION_X86_64_SAR, ///< RegisterDescriptor reg | Immediate imm, RegisterDescriptor reg
-  INSTRUCTION_X86_64_SHR, ///< RegisterDescriptor reg | Immediate imm, RegisterDescriptor reg
-
-  /// Stack instructions.
-  INSTRUCTION_X86_64_PUSH,
-  INSTRUCTION_X86_64_POP,
-
-  /// Control flow.
-  INSTRUCTION_X86_64_CALL,
-  INSTRUCTION_X86_64_JMP, ///< const char* label | RegisterDescriptor reg
-  INSTRUCTION_X86_64_RET,
-  INSTRUCTION_X86_64_JCC, ///< enum IndirectJumpType_x86_64 type, const char* label
-
-  /// Memory stuff.
-  INSTRUCTION_X86_64_MOV,
-  INSTRUCTION_X86_64_LEA,
-
-  INSTRUCTION_X86_64_COUNT
-};
-
-enum InstructionOperands_x86_64 {
-  IMMEDIATE, ///< int64_t imm
-  MEMORY,    ///< RegisterDescriptor reg, int64_t offset
-  REGISTER,  ///< RegisterDescriptor reg
-  NAME,      ///< const char* name
-
-  IMMEDIATE_TO_REGISTER, ///< int64_t imm, RegisterDescriptor dest
-  IMMEDIATE_TO_MEMORY,   ///< int64_t imm, RegisterDescriptor address, int64_t offset
-  MEMORY_TO_REGISTER,    ///< RegisterDescriptor address, int64_t offset, RegisterDescriptor dest
-  NAME_TO_REGISTER,      ///< RegisterDescriptor address, const char* name, RegisterDescriptor dest
-  REGISTER_TO_MEMORY,    ///< RegisterDescriptor src, RegisterDescriptor address, int64_t offset
-  REGISTER_TO_REGISTER,  ///< RegisterDescriptor src, RegisterDescriptor dest
-  REGISTER_TO_NAME,      ///< RegisterDescriptor src, RegisterDescriptor address, const char* name
-};
-
-const char *instruction_mnemonic_x86_64(enum CodegenOutputFormat fmt, enum Instructions_x86_64 instruction) {
-  ASSERT(INSTRUCTION_X86_64_COUNT == 20, "ERROR: instruction_mnemonic_x86_64() must exhaustively handle all instructions.");
-  // x86_64 instructions that aren't different across syntaxes can go here!
-  switch (instruction) {
-    default: break;
-    case INSTRUCTION_X86_64_ADD: return "add";
-    case INSTRUCTION_X86_64_SUB: return "sub";
-    // case INSTRUCTION_X86_64_MUL: return "mul";
-    case INSTRUCTION_X86_64_IMUL: return "imul";
-    // case INSTRUCTION_X86_64_DIV: return "div";
-    case INSTRUCTION_X86_64_IDIV: return "idiv";
-    case INSTRUCTION_X86_64_SAL: return "sal";
-    case INSTRUCTION_X86_64_SAR: return "sar";
-    case INSTRUCTION_X86_64_SHR: return "shr";
-    case INSTRUCTION_X86_64_PUSH: return "push";
-    case INSTRUCTION_X86_64_POP: return "pop";
-    case INSTRUCTION_X86_64_XOR: return "xor";
-    case INSTRUCTION_X86_64_CMP: return "cmp";
-    case INSTRUCTION_X86_64_CALL: return "call";
-    case INSTRUCTION_X86_64_JMP: return "jmp";
-    case INSTRUCTION_X86_64_RET: return "ret";
-    case INSTRUCTION_X86_64_MOV: return "mov";
-    case INSTRUCTION_X86_64_LEA: return "lea";
-    case INSTRUCTION_X86_64_SETCC: return "set";
-    case INSTRUCTION_X86_64_TEST: return "test";
-    case INSTRUCTION_X86_64_JCC: return "j";
-  }
-
-  switch (fmt) {
-    default: panic("instruction_mnemonic_x86_64(): Unknown output format.");
-
-    case CG_FMT_x86_64_GAS:
-    switch (instruction) {
-      default: panic("instruction_mnemonic_x86_64(): Unknown instruction.");
-      case INSTRUCTION_X86_64_CQO: return "cqto";
-    }
-  }
-}
-
-void femit_x86_64_imm_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  int64_t immediate                    = va_arg(args, int64_t);
-  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *destination = register_name(destination_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s $%" PRId64 ", %%%s\n",
-              mnemonic, immediate, destination);
-      break;
-    default: panic("ERROR: femit_x86_64_imm_to_reg(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_imm_to_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  int64_t immediate                    = va_arg(args, int64_t);
-  RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
-  int64_t offset                       = va_arg(args, int64_t);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *address = register_name(address_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s $%" PRId64 ", %" PRId64 "(%%%s)\n",
-              mnemonic, immediate, offset, address);
-      break;
-    default: panic("ERROR: femit_x86_64_imm_to_mem(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_mem_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
-  int64_t offset                           = va_arg(args, int64_t);
-  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *address = register_name(address_register);
-  const char *destination = register_name(destination_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s %" PRId64 "(%%%s), %%%s\n",
-              mnemonic, offset, address, destination);
-      break;
-    default: panic("ERROR: femit_x86_64_mem_to_reg(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_name_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
-  char *name                               = va_arg(args, char *);
-  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *address = register_name(address_register);
-  const char *destination = register_name(destination_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s %s(%%%s), %%%s\n",
-              mnemonic, name, address, destination);
-      break;
-    default: panic("ERROR: femit_x86_64_name_to_reg(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_reg_to_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  RegisterDescriptor source_register   = va_arg(args, RegisterDescriptor);
-  RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
-  int64_t offset                       = va_arg(args, int64_t);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *source = register_name(source_register);
-  const char *address = register_name(address_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s %%%s, %" PRId64 "(%%%s)\n",
-              mnemonic, source, offset, address);
-      break;
-    default: panic("ERROR: femit_x86_64_reg_to_mem(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_reg_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  RegisterDescriptor source_register       = va_arg(args, RegisterDescriptor);
-  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *source = register_name(source_register);
-  const char *destination = register_name(destination_register);
-
-  // Optimise away moves from a register to itself
-  if (inst == INSTRUCTION_X86_64_MOV && source_register == destination_register) return;
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s %%%s, %%%s\n",
-              mnemonic, source, destination);
-      break;
-    default: panic("ERROR: femit_x86_64_reg_to_reg(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_reg_to_name(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  RegisterDescriptor source_register  = va_arg(args, RegisterDescriptor);
-  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
-  char *name                               = va_arg(args, char *);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *source = register_name(source_register);
-  const char *address = register_name(address_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s %%%s, %s(%%%s)\n",
-          mnemonic, source, name, address);
-      break;
-    default: panic("ERROR: femit_x86_64_reg_to_name(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  int64_t offset                           = va_arg(args, int64_t);
-  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *address = register_name(address_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s %" PRId64 "(%%%s)\n",
-              mnemonic, offset, address);
-      break;
-    default: panic("ERROR: femit_x86_64_mem(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  RegisterDescriptor source_register   = va_arg(args, RegisterDescriptor);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *source = register_name(source_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s %%%s\n",
-              mnemonic, source);
-      break;
-    default: panic("ERROR: femit_x86_64_reg(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_imm(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  int64_t immediate = va_arg(args, int64_t);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s $%" PRId64 "\n",
-              mnemonic, immediate);
-      break;
-    default: panic("ERROR: femit_x86_64_imm(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64_indirect_branch(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
-  RegisterDescriptor address_register   = va_arg(args, RegisterDescriptor);
-
-  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
-  const char *address = register_name(address_register);
-
-  switch (context->format) {
-    case CG_FMT_x86_64_GAS:
-      fprintf(context->code, "%s *%%%s\n",
-              mnemonic, address);
-      break;
-    default: panic("ERROR: femit_x86_64_indirect_branch(): Unsupported format %d", context->format);
-  }
-}
-
-void femit_x86_64
-(CodegenContext *context,
- enum Instructions_x86_64 instruction,
- ...
- )
-{
-  va_list args;
-  va_start(args, instruction);
-
-  ASSERT(context);
-  ASSERT(INSTRUCTION_X86_64_COUNT == 20, "femit_x86_64() must exhaustively handle all x86_64 instructions.");
-
-  switch (instruction) {
-  case INSTRUCTION_X86_64_ADD:
-  case INSTRUCTION_X86_64_SUB:
-  case INSTRUCTION_X86_64_TEST:
-  case INSTRUCTION_X86_64_XOR:
-  case INSTRUCTION_X86_64_CMP:
-  case INSTRUCTION_X86_64_MOV: {
-    enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operands) {
-      default: panic("Unhandled operand type %d in x86_64 code generation for %d.", operands, instruction);
-      case IMMEDIATE_TO_REGISTER: femit_x86_64_imm_to_reg(context, instruction, args); break;
-      case IMMEDIATE_TO_MEMORY: femit_x86_64_imm_to_mem(context, instruction, args); break;
-      case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
-      case REGISTER_TO_MEMORY: femit_x86_64_reg_to_mem(context, instruction, args); break;
-      case REGISTER_TO_REGISTER: femit_x86_64_reg_to_reg(context, instruction, args); break;
-      case REGISTER_TO_NAME: femit_x86_64_reg_to_name(context, instruction, args); break;
-      case NAME_TO_REGISTER: femit_x86_64_name_to_reg(context, instruction, args); break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_LEA: {
-    enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operands) {
-      default: panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or NAME_TO_REGISTER operand type with LEA instruction.");
-      case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
-      case NAME_TO_REGISTER: femit_x86_64_name_to_reg(context, instruction, args); break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_IMUL: {
-    enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operands) {
-      default: panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or REGISTER_TO_REGISTER operand type with IMUL instruction.");
-      case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
-      case REGISTER_TO_REGISTER: femit_x86_64_reg_to_reg(context, instruction, args); break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_IDIV: {
-    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operand) {
-      default: panic("femit_x86_64() only accepts MEMORY or REGISTER operand type with IDIV instruction.");
-      case MEMORY: femit_x86_64_mem(context, instruction, args); break;
-      case REGISTER: femit_x86_64_reg(context, instruction, args); break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_SAL:
-  case INSTRUCTION_X86_64_SAR:
-  case INSTRUCTION_X86_64_SHR: {
-    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operand) {
-      default: panic("femit_x86_64() only accepts REGISTER OR IMMEDIATE_TO_REGISTER operand type with shift instructions.");
-      case IMMEDIATE_TO_REGISTER: femit_x86_64_imm_to_reg(context, instruction, args); break;
-      case REGISTER: {
-        RegisterDescriptor register_to_shift = va_arg(args, RegisterDescriptor);
-        const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
-        const char *cl = register_name_8(REG_X86_64_RCX);
-
-        switch (context->format) {
-          case CG_FMT_x86_64_GAS:
-            fprintf(context->code, "%s %%%s, %%%s\n",
-                    mnemonic, cl, register_name(register_to_shift));
-            break;
-          default: panic("ERROR: femit_x86_64(): Unsupported format %d for shift instruction", context->format);
-        }
-      } break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_JMP:
-  case INSTRUCTION_X86_64_CALL: {
-    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operand) {
-      default: panic("femit_x86_64() only accepts REGISTER or NAME operand type with CALL/JMP instruction.");
-      case REGISTER: femit_x86_64_indirect_branch(context, instruction, args); break;
-      case NAME: {
-        char *label = va_arg(args, char *);
-        const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
-
-        switch (context->format) {
-          case CG_FMT_x86_64_GAS:
-            fprintf(context->code, "%s %s\n",
-                mnemonic, label);
-            break;
-          default: panic("ERROR: femit_x86_64(): Unsupported format %d for CALL/JMP instruction", context->format);
-        }
-      } break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_PUSH: {
-    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operand) {
-      default: panic("femit_x86_64() only accepts REGISTER, MEMORY, or IMMEDIATE operand type with PUSH instruction.");
-      case REGISTER: femit_x86_64_reg(context, instruction, args); break;
-      case MEMORY: femit_x86_64_mem(context, instruction, args); break;
-      case IMMEDIATE: femit_x86_64_imm(context, instruction, args); break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_POP: {
-    enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
-    switch (operand) {
-      default: panic("femit_x86_64() only accepts REGISTER or MEMORY operand type with POP instruction.");
-      case REGISTER: femit_x86_64_reg(context, instruction, args); break;
-      case MEMORY: femit_x86_64_mem(context, instruction, args); break;
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_SETCC: {
-    enum ComparisonType comparison_type = va_arg(args, enum ComparisonType);
-    RegisterDescriptor value_register = va_arg(args, RegisterDescriptor);
-
-    const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
-    const char *value = register_name_8(value_register);
-
-    switch (context->format) {
-      case CG_FMT_x86_64_GAS:
-        fprintf(context->code, "%s%s %%%s\n",
-            mnemonic,
-            comparison_suffixes_x86_64[comparison_type], value);
-        break;
-      default: panic("ERROR: femit_x86_64(): Unsupported format %d", context->format);
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_JCC: {
-    enum IndirectJumpType_x86_64 type = va_arg(args, enum IndirectJumpType_x86_64);
-    ASSERT(type < JUMP_TYPE_COUNT, "femit_x86_64_direct_branch(): Invalid jump type %d", type);
-    char *label = va_arg(args, char *);
-
-    const char *mnemonic = instruction_mnemonic_x86_64(context->format, INSTRUCTION_X86_64_JCC);
-
-    switch (context->format) {
-      case CG_FMT_x86_64_GAS:
-        fprintf(context->code, "%s%s %s\n",
-            mnemonic, jump_type_names_x86_64[type], label);
-        break;
-      default: panic("ERROR: femit_x86_64_direct_branch(): Unsupported format %d", context->format);
-    }
-  } break;
-
-  case INSTRUCTION_X86_64_RET:
-  case INSTRUCTION_X86_64_CQO: {
-    const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
-    fprintf(context->code, "%s\n", mnemonic);
-  } break;
-
-  default: panic("Unhandled instruction in x86_64 code generation: %d.", instruction);
-  }
-
-  va_end(args);
-}
-
-/// Creates a context for the CG_FMT_x86_64_MSWIN architecture.
-CodegenContext *codegen_context_x86_64_gas_mswin_create(CodegenContext *parent) {
-  RegisterPool pool;
-
-  // If this is the top level context, create the registers.
-  // Otherwise, shallow copy register pool to child context.
-  if (!parent) {
-    Register *registers = calloc(REG_X86_64_COUNT, sizeof(Register));
-    FOR_ALL_X86_64_REGISTERS(INIT_REGISTER)
-
-    // Link to MSDN documentation (surely will fall away, but it's been Internet Archive'd).
-    // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#callercallee-saved-registers
-    // https://web.archive.org/web/20220916164241/https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170
-    // "The x64 ABI considers the registers RAX, RCX, RDX, R8, R9, R10, R11, and XMM0-XMM5 volatile."
-    // "The x64 ABI considers registers RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15, and XMM6-XMM15 nonvolatile."
-    size_t number_of_scratch_registers = 7;
-    Register **scratch_registers = calloc(number_of_scratch_registers, sizeof(Register *));
-    scratch_registers[0] = registers + REG_X86_64_RAX;
-    scratch_registers[1] = registers + REG_X86_64_RCX;
-    scratch_registers[2] = registers + REG_X86_64_RDX;
-    scratch_registers[3] = registers + REG_X86_64_R8;
-    scratch_registers[4] = registers + REG_X86_64_R9;
-    scratch_registers[5] = registers + REG_X86_64_R10;
-    scratch_registers[6] = registers + REG_X86_64_R11;
-
-    pool.registers = registers;
-    pool.scratch_registers = scratch_registers;
-    pool.num_scratch_registers = number_of_scratch_registers;
-    pool.num_registers = REG_X86_64_COUNT;
-  } else {
-    pool = parent->register_pool;
-  }
-
-  CodegenContext *cg_ctx = calloc(1,sizeof(CodegenContext));
-  if (parent) cg_ctx->code = parent->code;
-  cg_ctx->parent = parent;
-  cg_ctx->locals = environment_create(NULL);
-  cg_ctx->locals_offset = -32;
-  cg_ctx->register_pool = pool;
-  cg_ctx->format = CG_FMT_x86_64_GAS;
-  cg_ctx->call_convention = CG_CALL_CONV_MSWIN;
-  return cg_ctx;
-}
-
-/// Free a context created by codegen_context_x86_64_mswin_create.
-void codegen_context_x86_64_mswin_free(CodegenContext *ctx) {
-  // Only free the registers if this is the top-level context.
-  if (!ctx->parent) free(ctx->register_pool.registers);
-  // TODO(sirraide): Free environment.
-  free(ctx);
-}
-
-
-CodegenContext *create_codegen_context(CodegenContext *parent) {
-  ASSERT(parent, "create_codegen_context() can only create contexts when a parent is given.");
-  ASSERT(CG_FMT_COUNT == 1, "create_codegen_context() must exhaustively handle all codegen output formats.");
-  ASSERT(CG_CALL_CONV_COUNT == 2, "create_codegen_context() must exhaustively handle all calling conventions.");
-  if (parent->format == CG_FMT_x86_64_GAS) {
-    if (parent->call_convention == CG_CALL_CONV_MSWIN) {
-      return codegen_context_x86_64_gas_mswin_create(parent);
-    } else if (parent->call_convention == CG_CALL_CONV_MSWIN) {
-      // return codegen_context_x86_64_gas_linux_create(parent);
-    }
-  }
-  panic("create_codegen_context() could not create a new context from the given parent.");
-  return NULL; // Unreachable
-}
-
 //================================================================ BEG REGISTER STUFF
-
-void print_registers(CodegenContext *cg_ctx) {
-  for (size_t i = 0; i < cg_ctx->register_pool.num_registers; ++i) {
-    Register *reg = &cg_ctx->register_pool.registers[i];
-    printf("%s:%i\n", register_name(reg->descriptor), reg->in_use);
-  }
-}
 
 char register_descriptor_is_valid(CodegenContext *cg_ctx, RegisterDescriptor descriptor) {
   return descriptor >= 0 && descriptor < (int)cg_ctx->register_pool.num_registers;
@@ -772,48 +123,15 @@ symbol_address symbol_to_address(CodegenContext *cg_ctx, Node *symbol) {
   };
 }
 
-const char *comparison_suffixes_x86_64[COMPARE_COUNT] = {
-    "e",
-    "ne",
-    "l",
-    "le",
-    "g",
-    "ge",
-};
-
-void codegen_comparison_x86_64
-(CodegenContext *cg_context,
- Node *expression,
- enum ComparisonType type) {
-  ASSERT(type < COMPARE_COUNT, "Invalid comparison type");
-
-  FILE *code = cg_context->code;
-
-  expression->result_register = register_allocate(cg_context);
-
-  // Zero out result register.
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_XOR, REGISTER_TO_REGISTER, expression->result_register, expression->result_register);
-
-  // Perform the comparison.
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_CMP, REGISTER_TO_REGISTER,
-      expression->children->next_child->result_register,
-      expression->children->result_register);
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_SETCC, type, expression->result_register);
-
-  // Deallocate LHS and RHS result registers, comparison is complete.
-  register_deallocate(cg_context, expression->children->result_register);
-  register_deallocate(cg_context, expression->children->next_child->result_register);
-}
-
 // Forward declare codegen_function for codegen_expression
-Error codegen_function_x86_64_gas
+Error codegen_function
 (CodegenContext *cg_context,
  ParsingContext *context,
  ParsingContext **next_child_context,
  char *name,
  Node *function);
 
-Error codegen_expression_x86_64
+Error codegen_expression
 (CodegenContext *cg_context,
  ParsingContext *context,
  ParsingContext **next_child_context,
@@ -825,7 +143,6 @@ Error codegen_expression_x86_64
   Node *tmpnode = node_allocate();
   Node *iterator = NULL;
   FILE *code = cg_context->code;
-  long long count = 0;
 
   ParsingContext *original_context = context;
   //expression->result_register = -1;
@@ -838,11 +155,7 @@ Error codegen_expression_x86_64
     if (codegen_verbose) {
       fprintf(code, ";;#; INTEGER: %lld\n", expression->value.integer);
     }
-    expression->result_register = register_allocate(cg_context);
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV,
-                 IMMEDIATE_TO_REGISTER,
-                 (int64_t)expression->value.integer,
-                 expression->result_register);
+    expression->result_register = codegen_load_immediate(cg_context, expression->value.integer);
     break;
   case NODE_TYPE_FUNCTION_CALL:
     if (codegen_verbose) {
@@ -851,7 +164,7 @@ Error codegen_expression_x86_64
 
     // TODO: Should we technically save all in-use scratch registers?
     // Save RAX because function call will over-write it!
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH, REGISTER, REG_X86_64_RAX);
+    codegen_prepare_call(cg_context);
 
     // Setup function environment based on calling convention.
 
@@ -864,86 +177,63 @@ Error codegen_expression_x86_64
     if (strcmp(variable_type->value.symbol, "external function") == 0) {
       // TODO: Save RCX, RDX, R8, and R9 (they are scratch registers).
       // TODO: Only save scratch registers that are in-use.
-      // TODO: Don't generate `mov` if both operands are the same!
 
       // Put arguments in RCX, RDX, R8, R9, then on the stack in reverse order.
       if (iterator) {
         // Place first argument in RCX or XMM0
-        err = codegen_expression_x86_64
-          (cg_context, context, next_child_context, iterator);
+        err = codegen_expression(cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        // Ensure iterator result register is moved into RCX.
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                     iterator->result_register, REG_X86_64_RCX);
+
+        codegen_add_external_function_arg(cg_context, iterator->result_register);
         iterator = iterator->next_child;
       }
       if (iterator) {
         // Place second argument in RDX or XMM1
-        err = codegen_expression_x86_64
-          (cg_context, context, next_child_context, iterator);
+        err = codegen_expression(cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                     iterator->result_register, REG_X86_64_RDX);
+
+        codegen_add_external_function_arg(cg_context, iterator->result_register);
         iterator = iterator->next_child;
       }
       if (iterator) {
         // Place third argument in R8 or XMM2
-        err = codegen_expression_x86_64
-          (cg_context, context, next_child_context, iterator);
+        err = codegen_expression(cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                     iterator->result_register, REG_X86_64_R8);
+
+        codegen_add_external_function_arg(cg_context, iterator->result_register);
         iterator = iterator->next_child;
       }
       if (iterator) {
         // Place third argument in R9 or XMM3
-        err = codegen_expression_x86_64
-          (cg_context, context, next_child_context, iterator);
+        err = codegen_expression(cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                     iterator->result_register, REG_X86_64_R9);
+
+        codegen_add_external_function_arg(cg_context, iterator->result_register);
         iterator = iterator->next_child;
       }
 
       // TODO: Reverse rest of arguments, push on stack.
 
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_CALL, NAME, expression->children->value.symbol);
-
+      expression->result_register = codegen_perform_external_call(cg_context, expression->children->value.symbol);
     } else {
       // Push arguments on stack in order.
       while (iterator) {
-        err = codegen_expression_x86_64
-          (cg_context, context, next_child_context, iterator);
+        err = codegen_expression(cg_context, context, next_child_context, iterator);
         if (err.type) { return err; }
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH, REGISTER, iterator->result_register);
+        codegen_add_internal_function_arg(cg_context, iterator->result_register);
         register_deallocate(cg_context, iterator->result_register);
         iterator = iterator->next_child;
-        count += 8;
       }
 
-      err = codegen_expression_x86_64(cg_context, context, next_child_context, expression->children);
+      err = codegen_expression(cg_context, context, next_child_context, expression->children);
       if (err.type) { return err; }
 
       // Emit call
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_CALL, REGISTER, expression->children->result_register);
+      expression->result_register = codegen_perform_internal_call(cg_context, expression->children->result_register);
       register_deallocate(cg_context, expression->children->result_register);
     }
 
-    if (count) {
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER, count, REG_X86_64_RSP);
-    }
-
-    // Copy return value of function call from RAX to result register
-    expression->result_register = register_allocate(cg_context);
-    if (expression->result_register != REG_X86_64_RAX) {
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                   REG_X86_64_RAX, expression->result_register);
-      // Save overwritten in-use registers.
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP, REGISTER, REG_X86_64_RAX);
-    } else {
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
-                   (int64_t)8, REG_X86_64_RSP);
-    }
+    codegen_cleanup_call(cg_context);
 
     break;
   case NODE_TYPE_FUNCTION:
@@ -965,23 +255,24 @@ Error codegen_expression_x86_64
       // FIXME: Completely memory leaked here, no chance of freeing!
       result = label_generate();
     }
-    err = codegen_function_x86_64_gas(cg_context,
+    err = codegen_function(cg_context,
                                       context, next_child_context,
                                       result, expression);
 
     // Function returns beginning of instructions address.
     expression->result_register = register_allocate(cg_context);
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
-                 REG_X86_64_RIP, result,
-                 expression->result_register);
+    codegen_load_global_address_into(cg_context, result, expression->result_register);
+    /*femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
+        REG_X86_64_RIP, result,
+        expression->result_register);*/
     break;
   case NODE_TYPE_DEREFERENCE:
     if (codegen_verbose) {
       fprintf(code, ";;#; Dereference\n");
     }
-    err = codegen_expression_x86_64(cg_context,
-                                    context, next_child_context,
-                                    expression->children);
+    err = codegen_expression(cg_context,
+                             context, next_child_context,
+                             expression->children);
     if (err.type) { return err; }
     expression->result_register = expression->children->result_register;
     break;
@@ -989,19 +280,15 @@ Error codegen_expression_x86_64
     if (codegen_verbose) {
       fprintf(code, ";;#; Addressof\n");
     }
-    expression->result_register = register_allocate(cg_context);
+
     symbol_address address = symbol_to_address(cg_context, expression->children);
     switch (address.mode) {
       case SYMBOL_ADDRESS_MODE_ERROR: return address.error;
       case SYMBOL_ADDRESS_MODE_GLOBAL:
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
-                     REG_X86_64_RIP, address.global,
-                     expression->result_register);
+        expression->result_register = codegen_load_global_address(cg_context, address.global);
         break;
       case SYMBOL_ADDRESS_MODE_LOCAL:
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, MEMORY_TO_REGISTER,
-                     REG_X86_64_RBP, address.local,
-                     expression->result_register);
+        expression->result_register = codegen_load_local_address(cg_context, address.local);
         break;
     }
     break;
@@ -1025,25 +312,19 @@ Error codegen_expression_x86_64
     long long offset = base_type_size * expression->value.integer;
 
     // Load memory address of beginning of array.
-    expression->result_register = register_allocate(cg_context);
     symbol_address address = symbol_to_address(cg_context, expression->children);
     switch (address.mode) {
       case SYMBOL_ADDRESS_MODE_ERROR: return address.error;
       case SYMBOL_ADDRESS_MODE_GLOBAL:
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, NAME_TO_REGISTER,
-                     REG_X86_64_RIP, address.global,
-                     expression->result_register);
+        expression->result_register = codegen_load_global_address(cg_context, address.global);
         break;
       case SYMBOL_ADDRESS_MODE_LOCAL:
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_LEA, MEMORY_TO_REGISTER,
-                     REG_X86_64_RBP, address.local,
-                     expression->result_register);
+        expression->result_register = codegen_load_local_address(cg_context, address.local);
         break;
     }
     // Offset memory address by index.
     if (offset) {
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_ADD, IMMEDIATE_TO_REGISTER,
-          offset, expression->result_register);
+      codegen_add_immediate(cg_context, expression->result_register, offset);
     }
     break;
   }
@@ -1053,9 +334,9 @@ Error codegen_expression_x86_64
     }
 
     // Generate if condition expression code.
-    err = codegen_expression_x86_64(cg_context,
-                                    context, next_child_context,
-                                    expression->children);
+    err = codegen_expression(cg_context,
+                             context, next_child_context,
+                             expression->children);
     if (err.type) { return err; }
 
     if (codegen_verbose) {
@@ -1065,10 +346,7 @@ Error codegen_expression_x86_64
     // Generate code using result register from condition expression.
     char *otherwise_label = label_generate();
     char *after_otherwise_label = label_generate();
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_TEST, REGISTER_TO_REGISTER,
-                 expression->children->result_register,
-                 expression->children->result_register);
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_JCC, JUMP_TYPE_Z, otherwise_label);
+    codegen_branch_if_zero(cg_context, expression->children->result_register, otherwise_label);
     register_deallocate(cg_context, expression->children->result_register);
 
     if (codegen_verbose) {
@@ -1092,9 +370,9 @@ Error codegen_expression_x86_64
     Node *last_expr = NULL;
     Node *expr = expression->children->next_child->children;
     while (expr) {
-      err = codegen_expression_x86_64(cg_context,
-                                      ctx, &next_child_ctx,
-                                      expr);
+      err = codegen_expression(cg_context,
+                               ctx, &next_child_ctx,
+                               expr);
       if (err.type) { return err; }
       if (last_expr) {
         register_deallocate(cg_context, last_expr->result_register);
@@ -1105,10 +383,9 @@ Error codegen_expression_x86_64
 
     // Generate code to copy last expr result register to if result register.
     expression->result_register = register_allocate(cg_context);
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                 last_expr->result_register, expression->result_register);
+    codegen_copy_register(cg_context, last_expr->result_register, expression->result_register);
     register_deallocate(cg_context, last_expr->result_register);
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_JMP, NAME, after_otherwise_label);
+    codegen_branch(cg_context, after_otherwise_label);
 
     if (codegen_verbose) {
       fprintf(code, ";;#; If OTHERWISE\n");
@@ -1135,9 +412,9 @@ Error codegen_expression_x86_64
 
       expr = expression->children->next_child->next_child->children;
       while (expr) {
-        err = codegen_expression_x86_64(cg_context,
-                                        ctx, &next_child_ctx,
-                                        expr);
+        err = codegen_expression(cg_context,
+                                 ctx, &next_child_ctx,
+                                 expr);
         if (err.type) { return err; }
         if (last_expr) {
           register_deallocate(cg_context, last_expr->result_register);
@@ -1147,13 +424,11 @@ Error codegen_expression_x86_64
       }
       // Copy last_expr result register to if result register.
       if (last_expr) {
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                     last_expr->result_register, expression->result_register);
+        codegen_copy_register(cg_context, last_expr->result_register, expression->result_register);
         register_deallocate(cg_context, last_expr->result_register);
       }
     } else {
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, IMMEDIATE_TO_REGISTER,
-                   (int64_t)0, expression->result_register);
+      codegen_zero_register(cg_context, expression->result_register);
     }
 
     fprintf(code, "%s:\n", after_otherwise_label);
@@ -1170,157 +445,68 @@ Error codegen_expression_x86_64
     //printf("Codegenning binary operator %s\n", expression->value.symbol);
     //print_node(tmpnode,0);
 
-    err = codegen_expression_x86_64(cg_context,
-                                    context, next_child_context,
-                                    expression->children);
+    err = codegen_expression(cg_context,
+                             context, next_child_context,
+                             expression->children);
     if (err.type) { return err; }
-    err = codegen_expression_x86_64(cg_context,
-                                    context, next_child_context,
-                                    expression->children->next_child);
+    err = codegen_expression(cg_context,
+                             context, next_child_context,
+                             expression->children->next_child);
     if (err.type) { return err; }
 
     if (strcmp(expression->value.symbol, ">") == 0) {
-      codegen_comparison_x86_64(cg_context, expression, COMPARE_GT);
+      expression->result_register = codegen_comparison(cg_context,
+          CODEGEN_CLOBBER_OPERANDS, COMPARE_GT,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "<") == 0) {
-      codegen_comparison_x86_64(cg_context, expression, COMPARE_LT);
+      expression->result_register = codegen_comparison(cg_context,
+          CODEGEN_CLOBBER_OPERANDS, COMPARE_LT,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "=") == 0) {
-      codegen_comparison_x86_64(cg_context, expression, COMPARE_EQ);
+      expression->result_register = codegen_comparison(cg_context,
+          CODEGEN_CLOBBER_OPERANDS, COMPARE_EQ,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "+") == 0) {
-      // Plus/Addition
-      // https://www.felixcloutier.com/x86/add
-
-      // Use right hand side result register as our result since ADD is destructive!
-      expression->result_register = expression->children->next_child->result_register;
-
-      femit_x86_64
-        (cg_context,
-         INSTRUCTION_X86_64_ADD,
-         expression->children->result_register,
-         expression->children->next_child->result_register);
-
-      // Free no-longer-used left hand side result register.
-      register_deallocate(cg_context, expression->children->result_register);
+      expression->result_register = codegen_add(cg_context,
+          CODEGEN_CLOBBER_OPERANDS,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "-") == 0) {
-      // Minus/Subtraction
-      // https://www.felixcloutier.com/x86/sub
-
-      // Use right hand side result register as our result since SUB is destructive!
-      expression->result_register = expression->children->result_register;
-
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_SUB, REGISTER_TO_REGISTER,
-                   expression->children->next_child->result_register,
-                   expression->children->result_register);
-
-      // Free no-longer-used left hand side result register.
-      register_deallocate(cg_context, expression->children->next_child->result_register);
+      expression->result_register = codegen_subtract(cg_context,
+          CODEGEN_CLOBBER_OPERANDS,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "*") == 0) {
-      // Multiply
-      // https://www.felixcloutier.com/x86/mul
-      // https://www.felixcloutier.com/x86/imul
-
-      // Use right hand side result register as our result since ADD is destructive!
-      expression->result_register = expression->children->next_child->result_register;
-
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_IMUL, REGISTER_TO_REGISTER,
-                   expression->children->result_register,
-                   expression->children->next_child->result_register);
-
-      // Free no-longer-used left hand side result register.
-      register_deallocate(cg_context, expression->children->result_register);
-    } else if (strcmp(expression->value.symbol, "/") == 0
-               || strcmp(expression->value.symbol, "%") == 0) {
-      // Division/Modulo
-      // https://www.felixcloutier.com/x86/div
-      // https://www.felixcloutier.com/x86/idiv
-      // https://www.felixcloutier.com/x86/cwd:cdq:cqo
-
-      char modulo_flag = 0;
-      // TODO: Don't compare twice!
-      if (strcmp(expression->value.symbol, "%") == 0) {
-        modulo_flag = 1;
-      }
-
-      // Quotient is in RAX, Remainder in RDX; we must save and
-      // restore these registers before and after divide, sadly.
-
-      // TODO: We can optimize the outputted code by testing if LHS
-      // result register is RAX, in which case we can use it
-      // destructively as our division expression result register.
-
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
-                   REGISTER, REG_X86_64_RAX);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
-                   REGISTER, REG_X86_64_RDX);
-
-      // Load RAX with left hand side of division operator, if needed.
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                   expression->children->result_register, REG_X86_64_RAX);
-
-
-
-      // Sign-extend the value in RAX to RDX. RDX is treated as the
-      // 8 high bytes of a 16-byte number stored in RDX:RAX.
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_CQO);
-
-      // Call IDIV with right hand side of division operator.
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_IDIV,
-                   REGISTER, expression->children->next_child->result_register);
-
-      expression->result_register = register_allocate(cg_context);
-      if (modulo_flag) {
-        // Move return value from RDX into wherever it actually belongs.
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                     REG_X86_64_RDX, expression->result_register);
-      } else {
-        // Move return value from RAX into wherever it actually belongs.
-        femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                     REG_X86_64_RAX, expression->result_register);
-      }
-
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
-                   REGISTER, REG_X86_64_RDX);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
-                   REGISTER, REG_X86_64_RAX);
-
+      expression->result_register = codegen_multiply(cg_context,
+          CODEGEN_CLOBBER_OPERANDS,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
+    } else if (strcmp(expression->value.symbol, "/") == 0) {
+      expression->result_register = codegen_divide(cg_context,
+          CODEGEN_CLOBBER_OPERANDS,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
+    } else if (strcmp(expression->value.symbol, "%") == 0) {
+      expression->result_register = codegen_modulo(cg_context,
+          CODEGEN_CLOBBER_OPERANDS,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "<<") == 0) {
-      // Bitshift Left
-      // https://www.felixcloutier.com/x86/sal:sar:shl:shr
-
-      // Use left hand side result register as our result since SHL is destructive!
-      expression->result_register = expression->children->result_register;
-
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
-                   REGISTER, REG_X86_64_RCX);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                   expression->children->next_child->result_register, REG_X86_64_RCX);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_SAL, REGISTER,
-                   expression->children->result_register);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
-                   REGISTER, REG_X86_64_RCX);
-
-      // Free no-longer-used right hand side result register.
-      register_deallocate(cg_context, expression->children->next_child->result_register);
+      expression->result_register = codegen_shift_left(cg_context,
+          CODEGEN_CLOBBER_OPERANDS,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, ">>") == 0) {
-      // Minus/Subtraction
-      // https://www.felixcloutier.com/x86/sub
-
-      // Use left hand side result register as our result since SHR is destructive!
-      expression->result_register = expression->children->result_register;
-
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH,
-                   REGISTER, REG_X86_64_RCX);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                   expression->children->next_child->result_register, REG_X86_64_RCX);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_SAR, REGISTER,
-                   expression->children->result_register);
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_POP,
-                   REGISTER, REG_X86_64_RCX);
-
-      // Free no-longer-used right hand side result register.
-      register_deallocate(cg_context, expression->children->next_child->result_register);
+      expression->result_register = codegen_shift_right_arithmetic(cg_context,
+          CODEGEN_CLOBBER_OPERANDS,
+          expression->children->result_register,
+          expression->children->next_child->result_register);
     } else {
       fprintf(stderr, "Unrecognized binary operator: \"%s\"\n", expression->value.symbol);
-      ERROR_PREP(err, ERROR_GENERIC, "codegen_expression_x86_64() does not recognize binary operator");
+      ERROR_PREP(err, ERROR_GENERIC, "codegen_expression() does not recognize binary operator");
       return err;
     }
     break;
@@ -1328,8 +514,6 @@ Error codegen_expression_x86_64
     if (codegen_verbose) {
       fprintf(code, ";;#; Variable Access: \"%s\"\n", expression->value.symbol);
     }
-    expression->result_register = register_allocate(cg_context);
-
     // Find context that local variable resides in.
 
     CodegenContext *variable_residency = cg_context;
@@ -1341,17 +525,13 @@ Error codegen_expression_x86_64
     }
     if (!variable_residency) {
       // Global variable
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, NAME_TO_REGISTER,
-                   REG_X86_64_RIP, expression->value.symbol,
-                   expression->result_register);
+      expression->result_register = codegen_load_global(cg_context, expression->value.symbol);
     } else {
       // TODO: For each context change upwards (base pointer load), emit a call to load caller RBP
       // from current RBP into some register, and use that register as offset for memory access.
       // This will require us to differentiate scopes from stack frames, which is a problem for
       // another time :^). Good luck, future me!
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, MEMORY_TO_REGISTER,
-                   REG_X86_64_RBP, tmpnode->value.integer,
-                   expression->result_register);
+      expression->result_register = codegen_load_local(cg_context, tmpnode->value.integer);
     }
     break;
   case NODE_TYPE_VARIABLE_DECLARATION:
@@ -1384,9 +564,10 @@ Error codegen_expression_x86_64
     // TODO: Optimize to subtract all local variable's stack size at
     // beginning of function rather than throughout.
     //   Subtract type size in bytes from stack pointer
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_SUB, IMMEDIATE_TO_REGISTER,
-                 size_in_bytes, REG_X86_64_RSP);
+    codegen_alloca(cg_context, size_in_bytes);
     // Keep track of RBP offset.
+    // FIXME(Sirraide): this is probably no longer necessary since we now reset
+    //   RSP to RBP at the end of a function anyway.
     cg_context->locals_offset -= size_in_bytes;
     //   Kept in codegen context.
     environment_set(cg_context->locals, expression->children, node_integer(cg_context->locals_offset));
@@ -1411,8 +592,8 @@ Error codegen_expression_x86_64
     }
 
     // Codegen RHS
-    err = codegen_expression_x86_64(cg_context, context, next_child_context,
-                                    expression->children->next_child);
+    err = codegen_expression(cg_context, context, next_child_context,
+                             expression->children->next_child);
     if (err.type) { break; }
 
     if (expression->children->type == NODE_TYPE_VARIABLE_ACCESS) {
@@ -1420,25 +601,20 @@ Error codegen_expression_x86_64
       switch (address.mode) {
         case SYMBOL_ADDRESS_MODE_ERROR: return address.error;
         case SYMBOL_ADDRESS_MODE_GLOBAL:
-          femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_NAME,
-                       expression->children->next_child->result_register,
-                       REG_X86_64_RIP, address.global);
+          codegen_store_global(cg_context, expression->children->next_child->result_register, address.global);
           break;
         case SYMBOL_ADDRESS_MODE_LOCAL:
-          femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_MEMORY,
-                       expression->children->next_child->result_register,
-                       REG_X86_64_RBP, address.local);
+          codegen_store_local(cg_context, expression->children->next_child->result_register, address.local);
           break;
       }
     } else {
       // Codegen LHS
-      err = codegen_expression_x86_64(cg_context, context, next_child_context,
-                                      expression->children);
+      err = codegen_expression(cg_context, context, next_child_context,
+                               expression->children);
       if (err.type) { break; }
-      femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_MEMORY,
-                   expression->children->next_child->result_register,
-                   expression->children->result_register, 0);
-
+      codegen_store(cg_context,
+                    expression->children->next_child->result_register,
+                    expression->children->result_register);
       register_deallocate(cg_context, expression->children->next_child->result_register);
       register_deallocate(cg_context, expression->children->result_register);
     }
@@ -1452,24 +628,7 @@ Error codegen_expression_x86_64
   return err;
 }
 
-void emit_function_header_x86_64(CodegenContext *cg_context) {
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_PUSH, REGISTER,
-               REG_X86_64_RBP);
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-               REG_X86_64_RSP, REG_X86_64_RBP);
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_SUB, IMMEDIATE_TO_REGISTER,
-               32, REG_X86_64_RSP);
-}
-
-void emit_function_footer_x86_64(CodegenContext *cg_context) {
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-               REG_X86_64_RBP, REG_X86_64_RSP);
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_POP, REGISTER,
-               REG_X86_64_RBP);
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_RET);
-}
-
-Error codegen_function_x86_64_gas
+Error codegen_function
 (CodegenContext *cg_context,
  ParsingContext *context,
  ParsingContext **next_child_context,
@@ -1480,7 +639,7 @@ Error codegen_function_x86_64_gas
   Error err = ok;
   FILE *code = cg_context->code;
 
-  cg_context = create_codegen_context(cg_context);
+  cg_context = codegen_context_create(cg_context);
 
   // Store base pointer integer offset within locals environment
   // Start at one to make space for pushed RBP in function header.
@@ -1497,17 +656,17 @@ Error codegen_function_x86_64_gas
   }
 
   // Nested function execution protection
+
   char after_name_buffer[1024] = {0};
   snprintf(after_name_buffer, 1024, "after%s", name);
   after_name_buffer[sizeof after_name_buffer - 1] = 0;
-  femit_x86_64(cg_context, INSTRUCTION_X86_64_JMP, NAME,
-               after_name_buffer);
+  codegen_branch(cg_context, after_name_buffer);
 
   // Function beginning label
   fprintf(code, "%s:\n", name);
 
   // Function header
-  emit_function_header_x86_64(cg_context);
+  codegen_function_prologue(cg_context);
 
   // Function body
   ParsingContext *ctx = context;
@@ -1525,7 +684,7 @@ Error codegen_function_x86_64_gas
   Node *last_expression = NULL;
   Node *expression = function->children->next_child->next_child->children;
   while (expression) {
-    err = codegen_expression_x86_64(cg_context, ctx, &next_child_ctx, expression);
+    err = codegen_expression(cg_context, ctx, &next_child_ctx, expression);
     register_deallocate(cg_context, expression->result_register);
     if (err.type) {
       print_error(err);
@@ -1535,26 +694,21 @@ Error codegen_function_x86_64_gas
     expression = expression->next_child;
   }
 
-  // Copy last expression result register to RAX
-  // femit() will optimise the move away if the result is already in RAX.
-  if (last_expression) {
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-                 last_expression->result_register, REG_X86_64_RAX);
-  }
+  codegen_set_return_value(cg_context, last_expression->result_register);
 
   // Function footer
-  emit_function_footer_x86_64(cg_context);
+  codegen_function_epilogue(cg_context);
 
   // Nested function execution jump label
   fprintf(code, "%s:\n", after_name_buffer);
   // after<function_label>:
 
   // Free context;
-  codegen_context_x86_64_mswin_free(cg_context);
+  codegen_context_free(cg_context);
   return ok;
 }
 
-Error codegen_program_x86_64(CodegenContext *cg_context, ParsingContext *context, Node *program) {
+Error codegen_program(CodegenContext *cg_context, ParsingContext *context, Node *program) {
   Error err = ok;
   FILE *code = cg_context->code;
 
@@ -1581,11 +735,7 @@ Error codegen_program_x86_64(CodegenContext *cg_context, ParsingContext *context
   }
   free(type_info);
 
-  fprintf(code,
-          ".section .text\n"
-          ".global main\n"
-          "main:\n");
-  emit_function_header_x86_64(cg_context);
+  codegen_entry_point(cg_context);
 
   ParsingContext *next_child_context = context->children;
   Node *last_expression = program->children;
@@ -1595,7 +745,7 @@ Error codegen_program_x86_64(CodegenContext *cg_context, ParsingContext *context
       expression = expression->next_child;
       continue;
     }
-    err = codegen_expression_x86_64(cg_context, context, &next_child_context, expression);
+    err = codegen_expression(cg_context, context, &next_child_context, expression);
     if (err.type) { return err; }
     register_deallocate(cg_context, expression->result_register);
     last_expression = expression;
@@ -1605,18 +755,17 @@ Error codegen_program_x86_64(CodegenContext *cg_context, ParsingContext *context
   // Copy last expression into RAX register for return value.
   // femit() will optimise the move away if the result is already in RAX.
   if (last_expression) {
-    femit_x86_64(cg_context, INSTRUCTION_X86_64_MOV, REGISTER_TO_REGISTER,
-        last_expression->result_register, REG_X86_64_RAX);
+    codegen_set_return_value(cg_context, last_expression->result_register);
   }
 
-  emit_function_footer_x86_64(cg_context);
+  codegen_function_epilogue(cg_context);
 
   return err;
 }
 
 //================================================================ END CG_FMT_x86_64_MSWIN
 
-Error codegen_program
+Error codegen
 (enum CodegenOutputFormat format,
  enum CodegenCallingConvention call_convention,
  char *filepath,
@@ -1636,25 +785,11 @@ Error codegen_program
     ERROR_PREP(err, ERROR_GENERIC, "codegen_program(): fopen failed to open file at path.");
     return err;
   }
-  if (format == CG_FMT_x86_64_GAS) {
-    // TODO: Handle call_convention for creating codegen context!
-    CodegenContext *cg_context;
-    if (call_convention == CG_CALL_CONV_MSWIN) {
-      cg_context = codegen_context_x86_64_gas_mswin_create(NULL);
-      cg_context->code = code;
-    } else if (call_convention == CG_CALL_CONV_LINUX) {
-      // TODO: Create codegen context for GAS linux assembly.
-      ERROR_PREP(err, ERROR_TODO, "Create codegen context for GAS linux x86_64 assembly.");
-      return err;
-    } else {
-      ERROR_PREP(err, ERROR_GENERIC, "Unrecognized calling convention!");
-      return err;
-    }
-    err = codegen_program_x86_64(cg_context, context, program);
-    codegen_context_x86_64_mswin_free(cg_context);
-  } else {
-    printf("ERROR: Unrecognized codegen format\n");
-  }
+
+  CodegenContext *cg_context = codegen_context_create_top_level(format, call_convention, code);
+  err = codegen_program(cg_context, context, program);
+  codegen_context_free(cg_context);
+
   fclose(code);
   return err;
 }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -432,52 +432,45 @@ Error codegen_expression
 
     if (strcmp(expression->value.symbol, ">") == 0) {
       expression->result_register = codegen_comparison(cg_context,
-          CODEGEN_CLOBBER_OPERANDS, COMPARE_GT,
+          COMPARE_GT,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "<") == 0) {
       expression->result_register = codegen_comparison(cg_context,
-          CODEGEN_CLOBBER_OPERANDS, COMPARE_LT,
+          COMPARE_LT,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "=") == 0) {
       expression->result_register = codegen_comparison(cg_context,
-          CODEGEN_CLOBBER_OPERANDS, COMPARE_EQ,
+          COMPARE_EQ,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "+") == 0) {
       expression->result_register = codegen_add(cg_context,
-          CODEGEN_CLOBBER_OPERANDS,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "-") == 0) {
       expression->result_register = codegen_subtract(cg_context,
-          CODEGEN_CLOBBER_OPERANDS,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "*") == 0) {
       expression->result_register = codegen_multiply(cg_context,
-          CODEGEN_CLOBBER_OPERANDS,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "/") == 0) {
       expression->result_register = codegen_divide(cg_context,
-          CODEGEN_CLOBBER_OPERANDS,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "%") == 0) {
       expression->result_register = codegen_modulo(cg_context,
-          CODEGEN_CLOBBER_OPERANDS,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, "<<") == 0) {
       expression->result_register = codegen_shift_left(cg_context,
-          CODEGEN_CLOBBER_OPERANDS,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else if (strcmp(expression->value.symbol, ">>") == 0) {
       expression->result_register = codegen_shift_right_arithmetic(cg_context,
-          CODEGEN_CLOBBER_OPERANDS,
           expression->children->result_register,
           expression->children->next_child->result_register);
     } else {

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -9,8 +9,6 @@
 typedef int RegisterDescriptor;
 
 typedef struct Register {
-  /// What will be emitted when referencing this register, i.e "%rax"
-  const char *name;
   /// If non-zero, this register is in use.
   char in_use;
   /// Identifies a register uniquely.
@@ -24,11 +22,6 @@ typedef struct RegisterPool {
   size_t num_scratch_registers;
   size_t num_registers;
 } RegisterPool;
-
-/// Used when initializing Register arrays for RegisterPool.
-#define INIT_REGISTER(registers, desc, reg_name)                        \
-  ((registers)[desc] = (Register){.name = (reg_name), .in_use = 0, .descriptor = (desc)})
-
 
 enum CodegenOutputFormat {
   CG_FMT_x86_64_GAS,
@@ -76,10 +69,6 @@ RegisterDescriptor register_allocate(CodegenContext *cg_ctx);
 
 void register_deallocate
 (CodegenContext *cg_ctx, RegisterDescriptor descriptor);
-
-const char *register_name
-(CodegenContext *cg_ctx, RegisterDescriptor descriptor);
-
 
 // Types of comparison to be implemented by codegen backend.
 enum ComparisonType {

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -33,7 +33,7 @@ struct CodegenContext {
   RegisterPool register_pool;
   enum CodegenOutputFormat format;
   enum CodegenCallingConvention call_convention;
-
+  enum CodegenAssemblyDialect dialect;
   /// Architecture-specific data.
   void *arch_data;
 };
@@ -44,6 +44,7 @@ extern char codegen_verbose;
 Error codegen
 (enum CodegenOutputFormat,
  enum CodegenCallingConvention,
+ enum CodegenAssemblyDialect,
  char *output_filepath,
  ParsingContext *context,
  Node *program);

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -4,6 +4,7 @@
 #include <environment.h>
 #include <error.h>
 #include <parser.h>
+#include <stdio.h>
 
 typedef int RegisterDescriptor;
 
@@ -48,6 +49,7 @@ typedef struct CodegenContext {
   struct CodegenContext *parent;
   /// LOCALS
   /// `-- SYMBOL (NAME) -> INTEGER (STACK OFFSET)
+  FILE* code;
   Environment *locals;
   long long locals_offset;
   RegisterPool register_pool;

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -1,7 +1,7 @@
 #ifndef CODEGEN_H
 #define CODEGEN_H
 
-#include "codegen/codegen_forward.h"
+#include <codegen/codegen_forward.h>
 
 #include <environment.h>
 #include <error.h>

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -1,45 +1,30 @@
 #ifndef CODEGEN_H
 #define CODEGEN_H
 
+#include "codegen/codegen_forward.h"
+
 #include <environment.h>
 #include <error.h>
 #include <parser.h>
 #include <stdio.h>
 
-typedef int RegisterDescriptor;
-
-typedef struct Register {
+struct Register {
   /// If non-zero, this register is in use.
   char in_use;
   /// Identifies a register uniquely.
   RegisterDescriptor descriptor;
-} Register;
+};
 
 /// Architecture-specific register information.
-typedef struct RegisterPool {
+struct RegisterPool {
   Register *registers;
   Register **scratch_registers;
   size_t num_scratch_registers;
   size_t num_registers;
-} RegisterPool;
-
-enum CodegenOutputFormat {
-  CG_FMT_x86_64_GAS,
-  CG_FMT_COUNT,
-
-  CG_FMT_DEFAULT = CG_FMT_x86_64_GAS,
 };
 
-enum CodegenCallingConvention {
-  CG_CALL_CONV_MSWIN,
-  CG_CALL_CONV_LINUX,
-  CG_CALL_CONV_COUNT,
-
-  CG_CALL_CONV_DEFAULT = CG_CALL_CONV_MSWIN,
-};
-
-typedef struct CodegenContext {
-  struct CodegenContext *parent;
+struct CodegenContext {
+  CodegenContext *parent;
   /// LOCALS
   /// `-- SYMBOL (NAME) -> INTEGER (STACK OFFSET)
   FILE* code;
@@ -48,12 +33,15 @@ typedef struct CodegenContext {
   RegisterPool register_pool;
   enum CodegenOutputFormat format;
   enum CodegenCallingConvention call_convention;
-} CodegenContext;
+
+  /// Architecture-specific data.
+  void *arch_data;
+};
 
 // TODO/FIXME: Make this a parameter affectable by command line arguments.
 extern char codegen_verbose;
 
-Error codegen_program
+Error codegen
 (enum CodegenOutputFormat,
  enum CodegenCallingConvention,
  char *output_filepath,
@@ -61,27 +49,11 @@ Error codegen_program
  Node *program);
 
 
-void print_registers(CodegenContext *cg_ctx);
-
 char register_descriptor_is_valid(CodegenContext *cg_ctx, RegisterDescriptor descriptor);
 
 RegisterDescriptor register_allocate(CodegenContext *cg_ctx);
 
 void register_deallocate
 (CodegenContext *cg_ctx, RegisterDescriptor descriptor);
-
-// Types of comparison to be implemented by codegen backend.
-enum ComparisonType {
-  COMPARE_EQ,
-  COMPARE_NE,
-  COMPARE_LT,
-  COMPARE_LE,
-  COMPARE_GT,
-  COMPARE_GE,
-
-  COMPARE_COUNT,
-};
-
-extern const char *comparison_suffixes_x86_64[COMPARE_COUNT];
 
 #endif /* CODEGEN_H */

--- a/src/codegen/codegen_forward.h
+++ b/src/codegen/codegen_forward.h
@@ -7,6 +7,14 @@ typedef struct Register Register;
 typedef struct RegisterPool RegisterPool;
 typedef struct CodegenContext CodegenContext;
 
+enum CodegenAssemblyDialect {
+  CG_ASM_DIALECT_ATT,
+  CG_ASM_DIALECT_INTEL,
+  CG_ASM_DIALECT_COUNT,
+
+  CG_ASM_DIALECT_DEFAULT = CG_ASM_DIALECT_ATT
+};
+
 enum CodegenOutputFormat {
   CG_FMT_x86_64_GAS,
   CG_FMT_COUNT,

--- a/src/codegen/codegen_forward.h
+++ b/src/codegen/codegen_forward.h
@@ -1,0 +1,43 @@
+#ifndef CODEGEN_FORWARD_H
+#define CODEGEN_FORWARD_H
+
+typedef int RegisterDescriptor;
+
+typedef struct Register Register;
+typedef struct RegisterPool RegisterPool;
+typedef struct CodegenContext CodegenContext;
+
+enum CodegenOutputFormat {
+  CG_FMT_x86_64_GAS,
+  CG_FMT_COUNT,
+
+  CG_FMT_DEFAULT = CG_FMT_x86_64_GAS,
+};
+
+enum CodegenCallingConvention {
+  CG_CALL_CONV_MSWIN,
+  CG_CALL_CONV_LINUX,
+  CG_CALL_CONV_COUNT,
+
+  CG_CALL_CONV_DEFAULT = CG_CALL_CONV_MSWIN,
+};
+
+// Types of comparison to be implemented by codegen backend.
+enum ComparisonType {
+  COMPARE_EQ,
+  COMPARE_NE,
+  COMPARE_LT,
+  COMPARE_LE,
+  COMPARE_GT,
+  COMPARE_GE,
+
+  COMPARE_COUNT,
+};
+
+// Whether to deallocate the lhs and rhs of an arithmetic operation.
+enum CodegenBinaryOpMode {
+  CODEGEN_PRESERVE_OPERANDS,
+  CODEGEN_CLOBBER_OPERANDS,
+};
+
+#endif // CODEGEN_FORWARD_H

--- a/src/codegen/codegen_forward.h
+++ b/src/codegen/codegen_forward.h
@@ -42,10 +42,4 @@ enum ComparisonType {
   COMPARE_COUNT,
 };
 
-// Whether to deallocate the lhs and rhs of an arithmetic operation.
-enum CodegenBinaryOpMode {
-  CODEGEN_PRESERVE_OPERANDS,
-  CODEGEN_CLOBBER_OPERANDS,
-};
-
 #endif // CODEGEN_FORWARD_H

--- a/src/codegen/codegen_platforms.c
+++ b/src/codegen/codegen_platforms.c
@@ -293,12 +293,11 @@ void codegen_copy_register
 /// Generate a comparison between two registers.
 RegisterDescriptor codegen_comparison
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  enum ComparisonType type,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_comparison_x86_64(cg_context, mode, type, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_comparison_x86_64(cg_context, type, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }
@@ -306,11 +305,10 @@ RegisterDescriptor codegen_comparison
 /// Add two registers together.
 RegisterDescriptor codegen_add
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_add_x86_64(cg_context, mode, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_add_x86_64(cg_context, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }
@@ -318,11 +316,10 @@ RegisterDescriptor codegen_add
 /// Subtract rhs from lhs.
 RegisterDescriptor codegen_subtract
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_subtract_x86_64(cg_context, mode, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_subtract_x86_64(cg_context, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }
@@ -330,11 +327,10 @@ RegisterDescriptor codegen_subtract
 /// Multiply two registers together.
 RegisterDescriptor codegen_multiply
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_multiply_x86_64(cg_context, mode, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_multiply_x86_64(cg_context, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }
@@ -342,11 +338,10 @@ RegisterDescriptor codegen_multiply
 /// Divide lhs by rhs.
 RegisterDescriptor codegen_divide
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_divide_x86_64(cg_context, mode, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_divide_x86_64(cg_context, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }
@@ -354,11 +349,10 @@ RegisterDescriptor codegen_divide
 /// Modulo lhs by rhs.
 RegisterDescriptor codegen_modulo
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_modulo_x86_64(cg_context, mode, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_modulo_x86_64(cg_context, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }
@@ -366,11 +360,10 @@ RegisterDescriptor codegen_modulo
 /// Shift lhs to the left by rhs.
 RegisterDescriptor codegen_shift_left
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_shift_left_x86_64(cg_context, mode, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_shift_left_x86_64(cg_context, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }
@@ -378,11 +371,10 @@ RegisterDescriptor codegen_shift_left
 /// Shift lhs to the right by rhs (arithmetic).
 RegisterDescriptor codegen_shift_right_arithmetic
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs) {
   switch (cg_context->format) {
-    case CG_FMT_x86_64_GAS: return codegen_shift_right_arithmetic_x86_64(cg_context, mode, lhs, rhs);
+    case CG_FMT_x86_64_GAS: return codegen_shift_right_arithmetic_x86_64(cg_context, lhs, rhs);
     default: panic("ERROR: Unrecognized codegen format");
   }
 }

--- a/src/codegen/codegen_platforms.c
+++ b/src/codegen/codegen_platforms.c
@@ -40,7 +40,7 @@ CodegenContext *codegen_context_create(CodegenContext *parent) {
   if (parent->format == CG_FMT_x86_64_GAS) {
     if (parent->call_convention == CG_CALL_CONV_MSWIN) {
       return codegen_context_x86_64_mswin_create(parent);
-    } else if (parent->call_convention == CG_CALL_CONV_MSWIN) {
+    } else if (parent->call_convention == CG_CALL_CONV_LINUX) {
       // return codegen_context_x86_64_gas_linux_create(parent);
     }
   }

--- a/src/codegen/codegen_platforms.c
+++ b/src/codegen/codegen_platforms.c
@@ -8,6 +8,7 @@
 CodegenContext *codegen_context_create_top_level
 (enum CodegenOutputFormat format,
  enum CodegenCallingConvention call_convention,
+ enum CodegenAssemblyDialect dialect,
  FILE* code) {
   CodegenContext *cg_context;
 
@@ -27,6 +28,7 @@ CodegenContext *codegen_context_create_top_level
   }
 
   cg_context->code = code;
+  cg_context->dialect = dialect;
   return cg_context;
 }
 

--- a/src/codegen/codegen_platforms.c
+++ b/src/codegen/codegen_platforms.c
@@ -1,6 +1,6 @@
-#include "codegen_platforms.h"
+#include <codegen/codegen_platforms.h>
 
-#include "x86_64/arch_x86_64.h"
+#include <codegen/x86_64/arch_x86_64.h>
 
 #include <codegen.h>
 #include <error.h>

--- a/src/codegen/codegen_platforms.c
+++ b/src/codegen/codegen_platforms.c
@@ -1,0 +1,426 @@
+#include "codegen_platforms.h"
+
+#include "x86_64/arch_x86_64.h"
+
+#include <codegen.h>
+#include <error.h>
+
+CodegenContext *codegen_context_create_top_level
+(enum CodegenOutputFormat format,
+ enum CodegenCallingConvention call_convention,
+ FILE* code) {
+  CodegenContext *cg_context;
+
+  if (format == CG_FMT_x86_64_GAS) {
+    // TODO: Handle call_convention for creating codegen context!
+    if (call_convention == CG_CALL_CONV_MSWIN) {
+      cg_context = codegen_context_x86_64_mswin_create(NULL);
+      ASSERT(cg_context);
+    } else if (call_convention == CG_CALL_CONV_LINUX) {
+      // TODO: Create codegen context for GAS linux assembly.
+      panic("Not implemented: Create codegen context for GAS linux x86_64 assembly.");
+    } else {
+      panic("Unrecognized calling convention!");
+    }
+  } else {
+    panic("Unrecognized codegen format");
+  }
+
+  cg_context->code = code;
+  return cg_context;
+}
+
+/// Create a codegen context from a parent context.
+CodegenContext *codegen_context_create(CodegenContext *parent) {
+  ASSERT(parent, "create_codegen_context() can only create contexts when a parent is given.");
+  ASSERT(CG_FMT_COUNT == 1, "create_codegen_context() must exhaustively handle all codegen output formats.");
+  ASSERT(CG_CALL_CONV_COUNT == 2, "create_codegen_context() must exhaustively handle all calling conventions.");
+  if (parent->format == CG_FMT_x86_64_GAS) {
+    if (parent->call_convention == CG_CALL_CONV_MSWIN) {
+      return codegen_context_x86_64_mswin_create(parent);
+    } else if (parent->call_convention == CG_CALL_CONV_MSWIN) {
+      // return codegen_context_x86_64_gas_linux_create(parent);
+    }
+  }
+  panic("create_codegen_context() could not create a new context from the given parent.");
+  return NULL; // Unreachable
+}
+
+/// Free a codegen context.
+void codegen_context_free(CodegenContext *context) {
+  if (context->format == CG_FMT_x86_64_GAS) {
+    if (context->call_convention == CG_CALL_CONV_MSWIN) {
+      return codegen_context_x86_64_mswin_free(context);
+    } else if (context->call_convention == CG_CALL_CONV_MSWIN) {
+      // return codegen_context_x86_64_gas_linux_free(parent);
+    }
+  }
+  panic("free_codegen_context() could not free the given context.");
+}
+
+/// Save state before a function call.
+void codegen_prepare_call(CodegenContext *cg_context) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_prepare_call_x86_64(cg_context); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Add an argument to the current function call.
+void codegen_add_external_function_arg(CodegenContext *cg_context, RegisterDescriptor arg) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_add_external_function_arg_x86_64(cg_context, arg); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Add an argument to the current function call.
+void codegen_add_internal_function_arg(CodegenContext *cg_context, RegisterDescriptor arg) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_add_internal_function_arg_x86_64(cg_context, arg); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Call an external function. Allocate and return a register containing the return value.
+RegisterDescriptor codegen_perform_external_call
+(CodegenContext *cg_context,
+ const char* function_name) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_perform_external_call_x86_64(cg_context, function_name);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Call an internal function. Allocate and return a register containing the return value.
+RegisterDescriptor codegen_perform_internal_call
+(CodegenContext *cg_context,
+ RegisterDescriptor function) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_perform_internal_call_x86_64(cg_context, function);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Clean up after a function call.
+void codegen_cleanup_call(CodegenContext *cg_context) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_cleanup_call_x86_64(cg_context); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Load the address of a global variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_global_address
+(CodegenContext *cg_context,
+ const char *name) {
+  RegisterDescriptor reg = register_allocate(cg_context);
+  codegen_load_global_address_into(cg_context, name, reg);
+  return reg;
+}
+
+/// Load the address of a local variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_local_address
+(CodegenContext *cg_context,
+ long long int offset) {
+  RegisterDescriptor reg = register_allocate(cg_context);
+  codegen_load_local_address_into(cg_context, offset, reg);
+  return reg;
+}
+
+/// Load the address of a global variable into a register.
+void codegen_load_global_address_into
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_load_global_address_into_x86_64(cg_context, name, target); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Load the address of a local variable into a register.
+void codegen_load_local_address_into
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_load_local_address_into_x86_64(cg_context, offset, target); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Load the value of global variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_global
+(CodegenContext *cg_context,
+ const char *name) {
+  RegisterDescriptor reg = register_allocate(cg_context);
+  codegen_load_global_into(cg_context, name, reg);
+  return reg;
+}
+
+/// Load the value of local variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_local
+(CodegenContext *cg_context,
+ long long int offset) {
+  RegisterDescriptor reg = register_allocate(cg_context);
+  codegen_load_local_into(cg_context, offset, reg);
+  return reg;
+}
+
+/// Load the value of global variable into a register.
+void codegen_load_global_into
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_load_global_into_x86_64(cg_context, name, target); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Load the value of local variable into a register.
+void codegen_load_local_into
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_load_local_into_x86_64(cg_context, offset, target); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Store a global variable.
+void codegen_store_global
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ const char *name) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_store_global_x86_64(cg_context, source, name); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Store a local variable.
+void codegen_store_local
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ long long int offset) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_store_local_x86_64(cg_context, source, offset); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Store data in the memory pointed to by the given address.
+void codegen_store
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ RegisterDescriptor address) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_store_x86_64(cg_context, source, address); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Add an immediate value to a register.
+void codegen_add_immediate
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ long long int immediate) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_add_immediate_x86_64(cg_context, reg, immediate); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Branch to a label if a register is zero.
+void codegen_branch_if_zero
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ const char *label) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_branch_if_zero_x86_64(cg_context, reg, label); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Branch to a label.
+void codegen_branch
+(CodegenContext *cg_context,
+ const char *label) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_branch_x86_64(cg_context, label); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Load an immediate value into a new register.
+RegisterDescriptor codegen_load_immediate
+(CodegenContext *cg_context,
+ long long int immediate) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_load_immediate_x86_64(cg_context, immediate);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Zero out a register.
+void codegen_zero_register
+(CodegenContext *cg_context,
+ RegisterDescriptor reg) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_zero_register_x86_64(cg_context, reg); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Copy a register to another register.
+void codegen_copy_register
+(CodegenContext *cg_context,
+ RegisterDescriptor src,
+ RegisterDescriptor dest) {
+  if (src == dest) return;
+
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_copy_register_x86_64(cg_context, src, dest); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Generate a comparison between two registers.
+RegisterDescriptor codegen_comparison
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ enum ComparisonType type,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_comparison_x86_64(cg_context, mode, type, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Add two registers together.
+RegisterDescriptor codegen_add
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_add_x86_64(cg_context, mode, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Subtract rhs from lhs.
+RegisterDescriptor codegen_subtract
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_subtract_x86_64(cg_context, mode, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Multiply two registers together.
+RegisterDescriptor codegen_multiply
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_multiply_x86_64(cg_context, mode, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Divide lhs by rhs.
+RegisterDescriptor codegen_divide
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_divide_x86_64(cg_context, mode, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Modulo lhs by rhs.
+RegisterDescriptor codegen_modulo
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_modulo_x86_64(cg_context, mode, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Shift lhs to the left by rhs.
+RegisterDescriptor codegen_shift_left
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_shift_left_x86_64(cg_context, mode, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Shift lhs to the right by rhs (arithmetic).
+RegisterDescriptor codegen_shift_right_arithmetic
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: return codegen_shift_right_arithmetic_x86_64(cg_context, mode, lhs, rhs);
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Allocate space on the stack.
+void codegen_alloca(CodegenContext *cg_context, long long int size) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_alloca_x86_64(cg_context, size); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Emit the function prologue.
+void codegen_function_prologue(CodegenContext *cg_context) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_prologue_x86_64(cg_context); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Emit the function epilogue.
+void codegen_function_epilogue(CodegenContext *cg_context) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_epilogue_x86_64(cg_context); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Set the return value of a function.
+void codegen_set_return_value(CodegenContext *cg_context, RegisterDescriptor value) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_set_return_value_x86_64(cg_context, value); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}
+
+/// Emit the entry point of the program.
+void codegen_entry_point(CodegenContext *cg_context) {
+  switch (cg_context->format) {
+    case CG_FMT_x86_64_GAS: codegen_entry_point_x86_64(cg_context); break;
+    default: panic("ERROR: Unrecognized codegen format");
+  }
+}

--- a/src/codegen/codegen_platforms.c
+++ b/src/codegen/codegen_platforms.c
@@ -53,7 +53,7 @@ void codegen_context_free(CodegenContext *context) {
   if (context->format == CG_FMT_x86_64_GAS) {
     if (context->call_convention == CG_CALL_CONV_MSWIN) {
       return codegen_context_x86_64_mswin_free(context);
-    } else if (context->call_convention == CG_CALL_CONV_MSWIN) {
+    } else if (context->call_convention == CG_CALL_CONV_LINUX) {
       // return codegen_context_x86_64_gas_linux_free(parent);
     }
   }

--- a/src/codegen/codegen_platforms.h
+++ b/src/codegen/codegen_platforms.h
@@ -137,7 +137,6 @@ void codegen_copy_register
 /// Generate a comparison between two registers.
 RegisterDescriptor codegen_comparison
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  enum ComparisonType type,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
@@ -145,49 +144,42 @@ RegisterDescriptor codegen_comparison
 /// Add two registers together.
 RegisterDescriptor codegen_add
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Subtract rhs from lhs.
 RegisterDescriptor codegen_subtract
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Multiply two registers together.
 RegisterDescriptor codegen_multiply
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Divide lhs by rhs.
 RegisterDescriptor codegen_divide
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Modulo lhs by rhs.
 RegisterDescriptor codegen_modulo
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Shift lhs to the left by rhs.
 RegisterDescriptor codegen_shift_left
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Shift lhs to the right by rhs (arithmetic).
 RegisterDescriptor codegen_shift_right_arithmetic
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 

--- a/src/codegen/codegen_platforms.h
+++ b/src/codegen/codegen_platforms.h
@@ -8,6 +8,7 @@
 CodegenContext *codegen_context_create_top_level
 (enum CodegenOutputFormat format,
  enum CodegenCallingConvention call_convention,
+ enum CodegenAssemblyDialect dialect,
  FILE* code);
 
 /// Create a codegen context from a parent context.

--- a/src/codegen/codegen_platforms.h
+++ b/src/codegen/codegen_platforms.h
@@ -1,0 +1,208 @@
+#ifndef CODEGEN_PLATFORMS_H
+#define CODEGEN_PLATFORMS_H
+
+#include "codegen_forward.h"
+#include <stdio.h>
+
+/// Create a top-level codegen context.
+CodegenContext *codegen_context_create_top_level
+(enum CodegenOutputFormat format,
+ enum CodegenCallingConvention call_convention,
+ FILE* code);
+
+/// Create a codegen context from a parent context.
+CodegenContext *codegen_context_create(CodegenContext *parent);
+
+/// Free a codegen context.
+void codegen_context_free(CodegenContext *parent);
+
+/// Save state before a function call.
+void codegen_prepare_call(CodegenContext *cg_context);
+
+/// Add an argument to the current external function call.
+void codegen_add_external_function_arg(CodegenContext *cg_context, RegisterDescriptor arg);
+
+/// Add an argument to the current function call.
+void codegen_add_internal_function_arg(CodegenContext *cg_context, RegisterDescriptor arg);
+
+/// Call an external function. Return the register containing the return value.
+RegisterDescriptor codegen_perform_external_call
+(CodegenContext *cg_context,
+ const char* function_name);
+
+/// Call an internal function. Return the register containing the return value.
+RegisterDescriptor codegen_perform_internal_call
+(CodegenContext *cg_context,
+ RegisterDescriptor function);
+
+/// Clean up after a function call.
+void codegen_cleanup_call(CodegenContext *cg_context);
+
+/// Load the address of global variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_global_address
+(CodegenContext *cg_context,
+ const char *name);
+
+/// Load the address of local variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_local_address
+(CodegenContext *cg_context,
+ long long int offset);
+
+/// Load the address of global variable into a register.
+void codegen_load_global_address_into
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target);
+
+/// Load the address of local variable into a register.
+void codegen_load_local_address_into
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target);
+
+/// Load the value of global variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_global
+(CodegenContext *cg_context,
+ const char *name);
+
+/// Load the value of local variable into a newly allocated register and return it.
+RegisterDescriptor codegen_load_local
+(CodegenContext *cg_context,
+ long long int offset);
+
+/// Load the value of global variable into a register.
+void codegen_load_global_into
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target);
+
+/// Load the value of local variable into a register.
+void codegen_load_local_into
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target);
+
+/// Store a global variable.
+void codegen_store_global
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ const char *name);
+
+/// Store a local variable.
+void codegen_store_local
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ long long int offset);
+
+/// Store data in the memory pointed to by the given address.
+void codegen_store
+(CodegenContext *cg_context,
+ RegisterDescriptor data,
+ RegisterDescriptor address);
+
+/// Add an immediate value to a register.
+void codegen_add_immediate
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ long long int immediate);
+
+/// Branch to a label if a register is zero.
+void codegen_branch_if_zero
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ const char *label);
+
+/// Branch to a label.
+void codegen_branch
+(CodegenContext *cg_context,
+ const char *label);
+
+/// Load an immediate value into a new register.
+RegisterDescriptor codegen_load_immediate
+(CodegenContext *cg_context,
+ long long int immediate);
+
+/// Zero out a register.
+void codegen_zero_register
+(CodegenContext *cg_context,
+ RegisterDescriptor reg);
+
+/// Copy a register to another register.
+void codegen_copy_register
+(CodegenContext *cg_context,
+ RegisterDescriptor src,
+ RegisterDescriptor dest);
+
+/// Generate a comparison between two registers.
+RegisterDescriptor codegen_comparison
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ enum ComparisonType type,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Add two registers together.
+RegisterDescriptor codegen_add
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Subtract rhs from lhs.
+RegisterDescriptor codegen_subtract
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Multiply two registers together.
+RegisterDescriptor codegen_multiply
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Divide lhs by rhs.
+RegisterDescriptor codegen_divide
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Modulo lhs by rhs.
+RegisterDescriptor codegen_modulo
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Shift lhs to the left by rhs.
+RegisterDescriptor codegen_shift_left
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Shift lhs to the right by rhs (arithmetic).
+RegisterDescriptor codegen_shift_right_arithmetic
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Allocate space on the stack.
+void codegen_alloca(CodegenContext *cg_context, long long int size);
+
+/// Emit the function prologue.
+void codegen_function_prologue(CodegenContext *cg_context);
+
+/// Emit the function epilogue.
+void codegen_function_epilogue(CodegenContext *cg_context);
+
+/// Set the return value of a function.
+void codegen_set_return_value(CodegenContext *cg_context, RegisterDescriptor value);
+
+/// Emit the entry point of the program.
+void codegen_entry_point(CodegenContext *cg_context);
+
+#endif // CODEGEN_PLATFORMS_H

--- a/src/codegen/codegen_platforms.h
+++ b/src/codegen/codegen_platforms.h
@@ -1,7 +1,7 @@
 #ifndef CODEGEN_PLATFORMS_H
 #define CODEGEN_PLATFORMS_H
 
-#include "codegen_forward.h"
+#include <codegen/codegen_forward.h>
 #include <stdio.h>
 
 /// Create a top-level codegen context.

--- a/src/codegen/x86_64/arch_x86_64.c
+++ b/src/codegen/x86_64/arch_x86_64.c
@@ -1,0 +1,1194 @@
+#include "arch_x86_64.h"
+
+#include <codegen.h>
+#include <error.h>
+#include <inttypes.h>
+#include <parser.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <typechecker.h>
+
+#define DEFINE_REGISTER_ENUM(name, ...) REG_##name,
+#define REGISTER_NAME_64(ident, name, ...) name,
+#define REGISTER_NAME_32(ident, name, name_32, ...) name_32,
+#define REGISTER_NAME_16(ident, name, name_32, name_16, ...) name_16,
+#define REGISTER_NAME_8(ident, name, name_32, name_16, name_8, ...) name_8,
+
+/// Used when initializing Register arrays for RegisterPool.
+#define INIT_REGISTER(ident, ...)  \
+  ((registers)[REG_##ident] = (Register){.in_use = 0, .descriptor = (REG_##ident)});
+
+/// Lookup tables for register names.
+#define DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(name, bits)                                        \
+  static const char *name(RegisterDescriptor descriptor) {                                             \
+    static const char* register_names[] = { FOR_ALL_X86_64_REGISTERS(REGISTER_NAME_##bits) };   \
+    if (descriptor < 0 || descriptor >= REG_COUNT) {                                     \
+      panic("ERROR::" #name "(): Could not find register with descriptor of %d\n", descriptor); \
+    }                                                                                           \
+    return register_names[descriptor];                                                          \
+  }
+
+enum Registers_x86_64 {
+  FOR_ALL_X86_64_REGISTERS(DEFINE_REGISTER_ENUM)
+      REG_COUNT
+};
+
+/// Define register_name and friends.
+DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name, 64)
+DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name_32, 32)
+DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name_16, 16)
+DEFINE_REGISTER_NAME_LOOKUP_FUNCTION(register_name_8, 8)
+
+#undef REGISTER_NAME_64
+#undef REGISTER_NAME_32
+#undef REGISTER_NAME_16
+#undef REGISTER_NAME_8
+
+#undef DEFINE_REGISTER_ENUM
+#undef DEFINE_REGISTER_NAME_LOOKUP_FUNCTION
+
+/// Types of conditional jump instructions (Jcc).
+/// Do NOT reorder these.
+enum IndirectJumpType_x86_64 {
+  JUMP_TYPE_A,
+  JUMP_TYPE_AE,
+  JUMP_TYPE_B,
+  JUMP_TYPE_BE,
+  JUMP_TYPE_C,
+  JUMP_TYPE_E,
+  JUMP_TYPE_Z,
+  JUMP_TYPE_G,
+  JUMP_TYPE_GE,
+  JUMP_TYPE_L,
+  JUMP_TYPE_LE,
+  JUMP_TYPE_NA,
+  JUMP_TYPE_NAE,
+  JUMP_TYPE_NB,
+  JUMP_TYPE_NBE,
+  JUMP_TYPE_NC,
+  JUMP_TYPE_NE,
+  JUMP_TYPE_NG,
+  JUMP_TYPE_NGE,
+  JUMP_TYPE_NL,
+  JUMP_TYPE_NLE,
+  JUMP_TYPE_NO,
+  JUMP_TYPE_NP,
+  JUMP_TYPE_NS,
+  JUMP_TYPE_NZ,
+  JUMP_TYPE_O,
+  JUMP_TYPE_P,
+  JUMP_TYPE_PE,
+  JUMP_TYPE_PO,
+  JUMP_TYPE_S,
+
+  JUMP_TYPE_COUNT,
+};
+
+/// Do NOT reorder these.
+static const char *jump_type_names_x86_64[] = {
+    "a",
+    "ae",
+    "b",
+    "be",
+    "c",
+    "e",
+    "z",
+    "g",
+    "ge",
+    "l",
+    "le",
+    "na",
+    "nae",
+    "nb",
+    "nbe",
+    "nc",
+    "ne",
+    "ng",
+    "nge",
+    "nl",
+    "nle",
+    "no",
+    "np",
+    "ns",
+    "nz",
+    "o",
+    "p",
+    "pe",
+    "po",
+    "s",
+};
+
+// TODO: All instructions we use in x86_64 should be in this enum.
+enum Instructions_x86_64 {
+  /// Arithmetic instructions.
+  I_ADD,
+  I_SUB,
+  // I_MUL,
+  I_IMUL,
+  // I_DIV,
+  I_IDIV,
+  I_XOR,
+  I_CMP,
+  I_TEST,
+  I_CQO,
+  I_SETCC,
+  I_SAL, ///< Reg reg | Immediate imm, Reg reg
+  I_SHL = I_SAL,
+  I_SAR, ///< Reg reg | Immediate imm, Reg reg
+  I_SHR, ///< Reg reg | Immediate imm, Reg reg
+
+  /// Stack instructions.
+  I_PUSH,
+  I_POP,
+
+  /// Control flow.
+  I_CALL,
+  I_JMP, ///< const char* label | Reg reg
+  I_RET,
+  I_JCC, ///< enum IndirectJumpType type, const char* label
+
+  /// Memory stuff.
+  I_MOV,
+  I_LEA,
+
+  /// Using this for anything other than Reg <-> Reg is a VERY bad
+  /// idea unless you know what you're doing.
+  I_XCHG,
+
+  I_COUNT
+};
+
+enum InstructionOperands_x86_64 {
+  IMMEDIATE, ///< int64_t imm
+  MEMORY,    ///< Reg reg, int64_t offset
+  REGISTER,  ///< Reg reg
+  NAME,      ///< const char* name
+
+  IMMEDIATE_TO_REGISTER, ///< int64_t imm, Reg dest
+  IMMEDIATE_TO_MEMORY,   ///< int64_t imm, Reg address, int64_t offset
+  MEMORY_TO_REGISTER,    ///< Reg address, int64_t offset, Reg dest
+  NAME_TO_REGISTER,      ///< Reg address, const char* name, Reg dest
+  REGISTER_TO_MEMORY,    ///< Reg src, Reg address, int64_t offset
+  REGISTER_TO_REGISTER,  ///< Reg src, Reg dest
+  REGISTER_TO_NAME,      ///< Reg src, Reg address, const char* name
+};
+
+const char *comparison_suffixes_x86_64[COMPARE_COUNT] = {
+    "e",
+    "ne",
+    "l",
+    "le",
+    "g",
+    "ge",
+};
+
+static const char *instruction_mnemonic_x86_64(enum CodegenOutputFormat fmt, enum Instructions_x86_64 instruction) {
+  ASSERT(I_COUNT == 21, "ERROR: instruction_mnemonic_x86_64() must exhaustively handle all instructions.");
+  // x86_64 instructions that aren't different across syntaxes can go here!
+  switch (instruction) {
+    default: break;
+    case I_ADD: return "add";
+    case I_SUB: return "sub";
+    // case I_MUL: return "mul";
+    case I_IMUL: return "imul";
+    // case I_DIV: return "div";
+    case I_IDIV: return "idiv";
+    case I_SAL: return "sal";
+    case I_SAR: return "sar";
+    case I_SHR: return "shr";
+    case I_PUSH: return "push";
+    case I_POP: return "pop";
+    case I_XOR: return "xor";
+    case I_CMP: return "cmp";
+    case I_CALL: return "call";
+    case I_JMP: return "jmp";
+    case I_RET: return "ret";
+    case I_MOV: return "mov";
+    case I_XCHG: return "xchg";
+    case I_LEA: return "lea";
+    case I_SETCC: return "set";
+    case I_TEST: return "test";
+    case I_JCC: return "j";
+  }
+
+  switch (fmt) {
+    default: panic("instruction_mnemonic_x86_64(): Unknown output format.");
+
+    case CG_FMT_x86_64_GAS:
+      switch (instruction) {
+        default: panic("instruction_mnemonic_x86_64(): Unknown instruction.");
+        case I_CQO: return "cqto";
+      }
+  }
+}
+
+static void femit_x86_64_imm_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  int64_t immediate                    = va_arg(args, int64_t);
+  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *destination = register_name(destination_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s $%" PRId64 ", %%%s\n",
+          mnemonic, immediate, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_imm_to_reg(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_imm_to_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  int64_t immediate                    = va_arg(args, int64_t);
+  RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
+  int64_t offset                       = va_arg(args, int64_t);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s $%" PRId64 ", %" PRId64 "(%%%s)\n",
+          mnemonic, immediate, offset, address);
+      break;
+    default: panic("ERROR: femit_x86_64_imm_to_mem(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_mem_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
+  int64_t offset                           = va_arg(args, int64_t);
+  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *address = register_name(address_register);
+  const char *destination = register_name(destination_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %" PRId64 "(%%%s), %%%s\n",
+          mnemonic, offset, address, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_mem_to_reg(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_name_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
+  char *name                               = va_arg(args, char *);
+  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *address = register_name(address_register);
+  const char *destination = register_name(destination_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %s(%%%s), %%%s\n",
+          mnemonic, name, address, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_name_to_reg(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_reg_to_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor source_register   = va_arg(args, RegisterDescriptor);
+  RegisterDescriptor address_register  = va_arg(args, RegisterDescriptor);
+  int64_t offset                       = va_arg(args, int64_t);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *source = register_name(source_register);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s, %" PRId64 "(%%%s)\n",
+          mnemonic, source, offset, address);
+      break;
+    default: panic("ERROR: femit_x86_64_reg_to_mem(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_reg_to_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor source_register       = va_arg(args, RegisterDescriptor);
+  RegisterDescriptor destination_register  = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *source = register_name(source_register);
+  const char *destination = register_name(destination_register);
+
+  // Optimise away moves from a register to itself
+  if (inst == I_MOV && source_register == destination_register) return;
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s, %%%s\n",
+          mnemonic, source, destination);
+      break;
+    default: panic("ERROR: femit_x86_64_reg_to_reg(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_reg_to_name(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor source_register  = va_arg(args, RegisterDescriptor);
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
+  char *name                               = va_arg(args, char *);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *source = register_name(source_register);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s, %s(%%%s)\n",
+          mnemonic, source, name, address);
+      break;
+    default: panic("ERROR: femit_x86_64_reg_to_name(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_mem(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  int64_t offset                           = va_arg(args, int64_t);
+  RegisterDescriptor address_register      = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %" PRId64 "(%%%s)\n",
+          mnemonic, offset, address);
+      break;
+    default: panic("ERROR: femit_x86_64_mem(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_reg(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor source_register   = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *source = register_name(source_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s %%%s\n",
+          mnemonic, source);
+      break;
+    default: panic("ERROR: femit_x86_64_reg(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_imm(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  int64_t immediate = va_arg(args, int64_t);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s $%" PRId64 "\n",
+          mnemonic, immediate);
+      break;
+    default: panic("ERROR: femit_x86_64_imm(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64_indirect_branch(CodegenContext *context, enum Instructions_x86_64 inst, va_list args) {
+  RegisterDescriptor address_register   = va_arg(args, RegisterDescriptor);
+
+  const char *mnemonic = instruction_mnemonic_x86_64(context->format, inst);
+  const char *address = register_name(address_register);
+
+  switch (context->format) {
+    case CG_FMT_x86_64_GAS:
+      fprintf(context->code, "%s *%%%s\n",
+          mnemonic, address);
+      break;
+    default: panic("ERROR: femit_x86_64_indirect_branch(): Unsupported format %d", context->format);
+  }
+}
+
+static void femit_x86_64
+(CodegenContext *context,
+ enum Instructions_x86_64 instruction,
+ ...)
+{
+  va_list args;
+  va_start(args, instruction);
+
+  ASSERT(context);
+  ASSERT(I_COUNT == 21, "femit_x86_64() must exhaustively handle all x86_64 instructions.");
+
+  switch (instruction) {
+    case I_ADD:
+    case I_SUB:
+    case I_TEST:
+    case I_XOR:
+    case I_CMP:
+    case I_MOV: {
+      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operands) {
+        default: panic("Unhandled operand type %d in x86_64 code generation for %d.", operands, instruction);
+        case IMMEDIATE_TO_REGISTER: femit_x86_64_imm_to_reg(context, instruction, args); break;
+        case IMMEDIATE_TO_MEMORY: femit_x86_64_imm_to_mem(context, instruction, args); break;
+        case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
+        case REGISTER_TO_MEMORY: femit_x86_64_reg_to_mem(context, instruction, args); break;
+        case REGISTER_TO_REGISTER: femit_x86_64_reg_to_reg(context, instruction, args); break;
+        case REGISTER_TO_NAME: femit_x86_64_reg_to_name(context, instruction, args); break;
+        case NAME_TO_REGISTER: femit_x86_64_name_to_reg(context, instruction, args); break;
+      }
+    } break;
+
+    case I_LEA: {
+      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operands) {
+        default: panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or NAME_TO_REGISTER operand type with LEA instruction.");
+        case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
+        case NAME_TO_REGISTER: femit_x86_64_name_to_reg(context, instruction, args); break;
+      }
+    } break;
+
+    case I_IMUL: {
+      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operands) {
+        default: panic("femit_x86_64() only accepts MEMORY_TO_REGISTER or REGISTER_TO_REGISTER operand type with IMUL instruction.");
+        case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
+        case REGISTER_TO_REGISTER: femit_x86_64_reg_to_reg(context, instruction, args); break;
+      }
+    } break;
+
+    case I_IDIV: {
+      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operand) {
+        default: panic("femit_x86_64() only accepts MEMORY or REGISTER operand type with IDIV instruction.");
+        case MEMORY: femit_x86_64_mem(context, instruction, args); break;
+        case REGISTER: femit_x86_64_reg(context, instruction, args); break;
+      }
+    } break;
+
+    case I_SAL:
+    case I_SAR:
+    case I_SHR: {
+      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operand) {
+        default: panic("femit_x86_64() only accepts REGISTER OR IMMEDIATE_TO_REGISTER operand type with shift instructions.");
+        case IMMEDIATE_TO_REGISTER: femit_x86_64_imm_to_reg(context, instruction, args); break;
+        case REGISTER: {
+          RegisterDescriptor register_to_shift = va_arg(args, RegisterDescriptor);
+          const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+          const char *cl = register_name_8(REG_RCX);
+
+          switch (context->format) {
+            case CG_FMT_x86_64_GAS:
+              fprintf(context->code, "%s %%%s, %%%s\n",
+                  mnemonic, cl, register_name(register_to_shift));
+              break;
+            default: panic("ERROR: femit_x86_64(): Unsupported format %d for shift instruction", context->format);
+          }
+        } break;
+      }
+    } break;
+
+    case I_JMP:
+    case I_CALL: {
+      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operand) {
+        default: panic("femit_x86_64() only accepts REGISTER or NAME operand type with CALL/JMP instruction.");
+        case REGISTER: femit_x86_64_indirect_branch(context, instruction, args); break;
+        case NAME: {
+          char *label = va_arg(args, char *);
+          const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+
+          switch (context->format) {
+            case CG_FMT_x86_64_GAS:
+              fprintf(context->code, "%s %s\n",
+                  mnemonic, label);
+              break;
+            default: panic("ERROR: femit_x86_64(): Unsupported format %d for CALL/JMP instruction", context->format);
+          }
+        } break;
+      }
+    } break;
+
+    case I_PUSH: {
+      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operand) {
+        default: panic("femit_x86_64() only accepts REGISTER, MEMORY, or IMMEDIATE operand type with PUSH instruction.");
+        case REGISTER: femit_x86_64_reg(context, instruction, args); break;
+        case MEMORY: femit_x86_64_mem(context, instruction, args); break;
+        case IMMEDIATE: femit_x86_64_imm(context, instruction, args); break;
+      }
+    } break;
+
+    case I_POP: {
+      enum InstructionOperands_x86_64 operand = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operand) {
+        default: panic("femit_x86_64() only accepts REGISTER or MEMORY operand type with POP instruction.");
+        case REGISTER: femit_x86_64_reg(context, instruction, args); break;
+        case MEMORY: femit_x86_64_mem(context, instruction, args); break;
+      }
+    } break;
+
+    case I_XCHG: {
+      enum InstructionOperands_x86_64 operands = va_arg(args, enum InstructionOperands_x86_64);
+      switch (operands) {
+        default: panic("femit_x86_64(): invalid operands for XCHG instruction: %d", operands);
+        case REGISTER_TO_REGISTER: femit_x86_64_reg_to_reg(context, instruction, args); break;
+        case MEMORY_TO_REGISTER: femit_x86_64_mem_to_reg(context, instruction, args); break;
+      }
+    } break;
+
+    case I_SETCC: {
+      enum ComparisonType comparison_type = va_arg(args, enum ComparisonType);
+      RegisterDescriptor value_register = va_arg(args, RegisterDescriptor);
+
+      const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+      const char *value = register_name_8(value_register);
+
+      switch (context->format) {
+        case CG_FMT_x86_64_GAS:
+          fprintf(context->code, "%s%s %%%s\n",
+              mnemonic,
+              comparison_suffixes_x86_64[comparison_type], value);
+          break;
+        default: panic("ERROR: femit_x86_64(): Unsupported format %d", context->format);
+      }
+    } break;
+
+    case I_JCC: {
+      enum IndirectJumpType_x86_64 type = va_arg(args, enum IndirectJumpType_x86_64);
+      ASSERT(type < JUMP_TYPE_COUNT, "femit_x86_64_direct_branch(): Invalid jump type %d", type);
+      char *label = va_arg(args, char *);
+
+      const char *mnemonic = instruction_mnemonic_x86_64(context->format, I_JCC);
+
+      switch (context->format) {
+        case CG_FMT_x86_64_GAS:
+          fprintf(context->code, "%s%s %s\n",
+              mnemonic, jump_type_names_x86_64[type], label);
+          break;
+        default: panic("ERROR: femit_x86_64_direct_branch(): Unsupported format %d", context->format);
+      }
+    } break;
+
+    case I_RET:
+    case I_CQO: {
+      const char *mnemonic = instruction_mnemonic_x86_64(context->format, instruction);
+      fprintf(context->code, "%s\n", mnemonic);
+    } break;
+
+    default: panic("Unhandled instruction in x86_64 code generation: %d.", instruction);
+  }
+
+  va_end(args);
+}
+
+/// X86_64-specific code generation state.
+typedef struct ArchData {
+  /// The type of function call that is currently being emitted.
+  enum {
+    FUNCTION_CALL_TYPE_NONE,
+    FUNCTION_CALL_TYPE_INTERNAL,
+    FUNCTION_CALL_TYPE_EXTERNAL,
+  } current_call;
+  /// The number of arguments emitted.
+  size_t call_arg_count;
+  char rax_in_use;
+} ArchData;
+
+/// Creates a context for the CG_FMT_x86_64_MSWIN architecture.
+CodegenContext *codegen_context_x86_64_mswin_create(CodegenContext *parent) {
+  RegisterPool pool;
+
+  // If this is the top level context, create the registers.
+  // Otherwise, shallow copy register pool to child context.
+  if (!parent) {
+    Register *registers = calloc(REG_COUNT, sizeof(Register));
+    FOR_ALL_X86_64_REGISTERS(INIT_REGISTER)
+
+    // Link to MSDN documentation (surely will fall away, but it's been Internet Archive'd).
+    // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#callercallee-saved-registers
+    // https://web.archive.org/web/20220916164241/https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170
+    // "The x64 ABI considers the registers RAX, RCX, RDX, R8, R9, R10, R11, and XMM0-XMM5 volatile."
+    // "The x64 ABI considers registers RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15, and XMM6-XMM15 nonvolatile."
+    size_t number_of_scratch_registers = 7;
+    Register **scratch_registers = calloc(number_of_scratch_registers, sizeof(Register *));
+    scratch_registers[0] = registers + REG_RAX;
+    scratch_registers[1] = registers + REG_RCX;
+    scratch_registers[2] = registers + REG_RDX;
+    scratch_registers[3] = registers + REG_R8;
+    scratch_registers[4] = registers + REG_R9;
+    scratch_registers[5] = registers + REG_R10;
+    scratch_registers[6] = registers + REG_R11;
+
+    pool.registers = registers;
+    pool.scratch_registers = scratch_registers;
+    pool.num_scratch_registers = number_of_scratch_registers;
+    pool.num_registers = REG_COUNT;
+  } else {
+    pool = parent->register_pool;
+  }
+
+  CodegenContext *cg_ctx = calloc(1,sizeof(CodegenContext));
+
+  // Shallow-copy state from the parent.
+  if (parent) {
+    cg_ctx->code = parent->code;
+    cg_ctx->arch_data = parent->arch_data;
+  } else {
+    cg_ctx->arch_data = calloc(1, sizeof(ArchData));
+  }
+
+  cg_ctx->parent = parent;
+  cg_ctx->locals = environment_create(NULL);
+  cg_ctx->locals_offset = -32;
+  cg_ctx->register_pool = pool;
+  cg_ctx->format = CG_FMT_x86_64_GAS;
+  cg_ctx->call_convention = CG_CALL_CONV_MSWIN;
+  return cg_ctx;
+}
+
+/// Free a context created by codegen_context_x86_64_mswin_create.
+void codegen_context_x86_64_mswin_free(CodegenContext *ctx) {
+  // Only free the registers and arch data if this is the top-level context.
+  if (!ctx->parent) {
+    free(ctx->register_pool.registers);
+    free(ctx->register_pool.scratch_registers);
+    free(ctx->arch_data);
+  }
+  // TODO(sirraide): Free environment.
+  free(ctx);
+}
+
+/// Load an immediate value into a new register.
+RegisterDescriptor codegen_load_immediate_x86_64
+(CodegenContext *cg_context,
+ long long int immediate) {
+  RegisterDescriptor result = register_allocate(cg_context);
+  femit_x86_64(cg_context, I_MOV,
+               IMMEDIATE_TO_REGISTER,
+               immediate, result);
+  return result;
+}
+
+/// Copy the return value from RAX into a new register.
+static RegisterDescriptor copy_return_value(CodegenContext *cg_context) {
+  ArchData *arch_data = cg_context->arch_data;
+  ASSERT(arch_data->current_call != FUNCTION_CALL_TYPE_NONE);
+
+  if (arch_data->rax_in_use) {
+    RegisterDescriptor result = register_allocate(cg_context);
+    femit_x86_64(cg_context, I_MOV,
+                 REGISTER_TO_REGISTER,
+                 REG_RAX, result);
+    return result;
+  }
+
+  return REG_RAX;
+}
+
+/// Calculate quotient and remainder of lhs by rhs.
+static RegisterDescriptor divmod
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ char wants_quotient,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  // Quotient is in RAX, Remainder in RDX; we must save and restore these
+  // registers before and after divide, if they were in use, unless either
+  // register is the lhs and rhs and we are allowed to clobber registers.
+  Register* rax = cg_context->register_pool.registers + REG_RAX;
+  Register* rdx = cg_context->register_pool.registers + REG_RDX;
+
+  char rax_pushed = rax->in_use && (mode == CODEGEN_PRESERVE_OPERANDS || (lhs != REG_RAX && rhs != REG_RAX));
+  char rdx_pushed = rdx->in_use && (mode == CODEGEN_PRESERVE_OPERANDS || (lhs != REG_RDX && rhs != REG_RDX));
+
+  if (rax_pushed) { femit_x86_64(cg_context, I_PUSH, REGISTER, REG_RAX); }
+  if (rdx_pushed) { femit_x86_64(cg_context, I_PUSH, REGISTER, REG_RDX); }
+
+  // In the unfortunate case that the rhs is in RAX or RDX, we must move
+  // it to a scratch register before we can divide.
+  char actual_rhs_is_scratch = 0;
+  RegisterDescriptor actual_rhs = rhs;
+  if (rhs == REG_RAX || rhs == REG_RDX) {
+    actual_rhs = register_allocate(cg_context);
+    femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, rhs, actual_rhs);
+    actual_rhs_is_scratch = 1;
+  }
+
+  // Load RAX with left hand side of division operator, if needed.
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, lhs, REG_RAX);
+
+  // Sign-extend the value in RAX to RDX. RDX is treated as the
+  // 8 high bytes of a 16-byte number stored in RDX:RAX.
+  femit_x86_64(cg_context, I_CQO);
+
+  // Call IDIV with right hand side of division operator.
+  femit_x86_64(cg_context, I_IDIV, REGISTER, actual_rhs);
+
+  // Copy the wanted result into a register. There are several optimisations
+  // that we can employ here. We pick the fist one that we can use.
+  //   - If either the lhs or rhs is RAX or RDX, depending on whether we want the
+  //     quotient or remainder, respectively, and we are allowed to clobber
+  //     registers, we can just return the corresponding register.
+  //   - If we are allowed to clobber registers, we can move the result into
+  //     either lhs or rhs.
+  //   - If we have allocated a scratch register for the rhs, we can move the
+  //     result into that register.
+  //   - Otherwise, we must allocate a new register.
+  RegisterDescriptor result;
+  if (mode == CODEGEN_CLOBBER_OPERANDS) {
+    if (wants_quotient && (lhs == REG_RAX || rhs == REG_RAX)) { result = REG_RAX; }
+    else if (!wants_quotient && (lhs == REG_RDX || rhs == REG_RDX)) { result = REG_RDX; }
+    else {
+      femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER,
+                   wants_quotient ? REG_RAX : REG_RDX,
+                   lhs);
+      result = lhs;
+    }
+  } else {
+    result = actual_rhs_is_scratch ? actual_rhs : register_allocate(cg_context);
+    femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER,
+                 wants_quotient ? REG_RAX : REG_RDX,
+                 result);
+  }
+
+  // Cleanup everything.
+  // If we allocated a scratch register for the rhs, free it unless it is the result.
+  if (actual_rhs_is_scratch && actual_rhs != result) {
+    register_deallocate(cg_context, actual_rhs);
+  }
+
+  // We must restore RAX and RDX if we pushed them.
+  if (rdx_pushed) { femit_x86_64(cg_context, I_POP, REGISTER, REG_RDX); }
+  if (rax_pushed) { femit_x86_64(cg_context, I_POP, REGISTER, REG_RAX); }
+
+  // At this point, we have already taken care of restoring everything
+  // that we had to preserve. We can now free any registers that we
+  // no longer need if we are allowed to clobber registers.
+  if (mode == CODEGEN_CLOBBER_OPERANDS) {
+    if (lhs != result) { register_deallocate(cg_context, lhs); }
+    if (rhs != result) { register_deallocate(cg_context, rhs); }
+  }
+
+  return result;
+}
+
+/// Shift lhs by rhs.
+static RegisterDescriptor shift
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ enum Instructions_x86_64 shift_instruction,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  Register* rcx = cg_context->register_pool.registers + REG_RCX;
+  if (mode == CODEGEN_CLOBBER_OPERANDS) {
+    // Save RCX if it's in use and not the same as lhs or rhs by swapping
+    // it with rhs. Otherwise, if the lhs is RCX, swap it with the rhs.
+    // Otherwise, move the rhs into RCX.
+    char save_rcx = rcx->in_use && (lhs != REG_RCX && rhs != REG_RCX);
+    if (save_rcx) {
+      femit_x86_64(cg_context, I_XCHG, REGISTER_TO_REGISTER, REG_RCX, rhs);
+    } else if (lhs == REG_RCX) {
+      femit_x86_64(cg_context, I_XCHG, REGISTER_TO_REGISTER, lhs, rhs);
+    } else {
+      femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, rhs, REG_RCX);
+    }
+
+    femit_x86_64(cg_context, shift_instruction, REGISTER, lhs);
+
+    // If we saved RCX, restore it. Deallocate rhs since it's no longer
+    // needed and return lhs.
+    if (save_rcx) {
+      femit_x86_64(cg_context, I_XCHG, REGISTER_TO_REGISTER, REG_RCX, rhs);
+    }
+    register_deallocate(cg_context, rhs);
+    return lhs;
+  } else {
+    RegisterDescriptor result = register_allocate(cg_context);
+    // If RCX is in use and not the result register, save it.
+    char rcx_saved = rcx->in_use && result != REG_RCX;
+    if (rcx_saved) { femit_x86_64(cg_context, I_PUSH, REGISTER, REG_RCX); }
+
+    // Move the rhs into RCX.
+    femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, rhs, REG_RCX);
+
+    // If the result is not RCX, move the lhs into it. Otherwise,
+    // save lhs and restore it after the shift.
+    if (result != REG_RCX) {
+      femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, lhs, result);
+      femit_x86_64(cg_context, shift_instruction, REGISTER, result);
+    } else {
+      femit_x86_64(cg_context, I_PUSH, REGISTER, lhs);
+      femit_x86_64(cg_context, shift_instruction, REGISTER, REG_RCX);
+      femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, lhs, result);
+      femit_x86_64(cg_context, I_POP, REGISTER, lhs);
+    }
+
+    // If we saved RCX, restore it.
+    if (rcx_saved) { femit_x86_64(cg_context, I_POP, REGISTER, REG_RCX); }
+    return result;
+  }
+}
+
+/// Save state before a function call.
+void codegen_prepare_call_x86_64(CodegenContext *cg_context) {
+  ArchData *arch_data = cg_context->arch_data;
+  if (arch_data->current_call != FUNCTION_CALL_TYPE_NONE) {
+    panic("Cannot prepare call if a call is already prepared");
+  }
+
+  arch_data->rax_in_use = cg_context->register_pool.registers[REG_RAX].in_use;
+  if (arch_data->rax_in_use) femit_x86_64(cg_context, I_PUSH, REGISTER, REG_RAX);
+}
+
+/// Add an argument to the current function call.
+void codegen_add_external_function_arg_x86_64(CodegenContext *cg_context, RegisterDescriptor arg) {
+  ArchData *arch_data = cg_context->arch_data;
+  switch (arch_data->current_call) {
+    case FUNCTION_CALL_TYPE_NONE: arch_data->current_call = FUNCTION_CALL_TYPE_EXTERNAL; break;
+    case FUNCTION_CALL_TYPE_EXTERNAL: break;
+    default: panic("Cannot add external argument if internal call is prepared");
+  }
+
+  switch (cg_context->call_convention) {
+    case CG_CALL_CONV_MSWIN: {
+      switch (arch_data->call_arg_count++) {
+        case 0: femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, arg, REG_RCX); break;
+        case 1: femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, arg, REG_RDX); break;
+        case 2: femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, arg, REG_R8); break;
+        case 3: femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, arg, REG_R9); break;
+        default: panic("Too many function arguments");
+      }
+    } break;
+
+    case CG_CALL_CONV_LINUX: {
+      ASSERT(0, "Not implemented.");
+    } break;
+
+    default: panic("Unsupported calling convention: %d.", cg_context->call_convention);
+  }
+}
+
+/// Add an argument to the current function call.
+void codegen_add_internal_function_arg_x86_64(CodegenContext *cg_context, RegisterDescriptor arg) {
+  ArchData *arch_data = cg_context->arch_data;
+  switch (arch_data->current_call) {
+    case FUNCTION_CALL_TYPE_NONE: arch_data->current_call = FUNCTION_CALL_TYPE_INTERNAL; break;
+    case FUNCTION_CALL_TYPE_INTERNAL: break;
+    default: panic("Cannot add internal argument if external call is prepared");
+  }
+
+  arch_data->call_arg_count++;
+  femit_x86_64(cg_context, I_PUSH, REGISTER, arg);
+}
+
+/// Call an external function. Returns the register containing the return value.
+RegisterDescriptor codegen_perform_external_call_x86_64
+(CodegenContext *cg_context,
+ const char* function_name) {
+  ArchData *arch_data = cg_context->arch_data;
+  switch (arch_data->current_call) {
+    case FUNCTION_CALL_TYPE_NONE: arch_data->current_call = FUNCTION_CALL_TYPE_EXTERNAL; break;
+    case FUNCTION_CALL_TYPE_EXTERNAL: break;
+    default: panic("Cannot perform external call after preparing internal call");
+  }
+
+  femit_x86_64(cg_context, I_CALL, NAME, function_name);
+  return copy_return_value(cg_context);
+}
+
+/// Call an internal function. Return the register containing the return value.
+RegisterDescriptor codegen_perform_internal_call_x86_64(CodegenContext *cg_context, RegisterDescriptor function) {
+  ArchData *arch_data = cg_context->arch_data;
+  switch (arch_data->current_call) {
+    case FUNCTION_CALL_TYPE_NONE: arch_data->current_call = FUNCTION_CALL_TYPE_INTERNAL; break;
+    case FUNCTION_CALL_TYPE_INTERNAL: break;
+    default: panic("Cannot perform internal call after preparing external call");
+  }
+
+  femit_x86_64(cg_context, I_CALL, REGISTER, function);
+  return copy_return_value(cg_context);
+}
+
+/// Clean up after a function call.
+void codegen_cleanup_call_x86_64(CodegenContext *cg_context) {
+  ArchData *arch_data = cg_context->arch_data;
+
+  switch (arch_data->current_call) {
+    // Pop arguments off the stack.
+    case FUNCTION_CALL_TYPE_EXTERNAL:
+      femit_x86_64(cg_context, I_ADD, IMMEDIATE_TO_REGISTER,
+                   arch_data->call_arg_count * 8, REG_RSP);
+      break;
+    case FUNCTION_CALL_TYPE_INTERNAL: break;
+    default: panic("No call to clean up");
+  }
+
+  // Restore rax if it was in use.
+  if (arch_data->rax_in_use) femit_x86_64(cg_context, I_POP, REGISTER, REG_RAX);
+  else femit_x86_64(cg_context, I_ADD, IMMEDIATE_TO_REGISTER,
+                    (int64_t)8, REG_RSP);
+
+  // Clean up the call state.
+  arch_data->current_call = FUNCTION_CALL_TYPE_NONE;
+  arch_data->call_arg_count = 0;
+  arch_data->rax_in_use = 0;
+}
+
+/// Load the address of a global variable into a newly allocated register and return it.
+void codegen_load_global_address_into_x86_64
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target) {
+  femit_x86_64(cg_context, I_LEA, NAME_TO_REGISTER,
+      REG_RIP, name,
+      target);
+}
+
+/// Load the address of a local variable into a newly allocated register and return it.
+void codegen_load_local_address_into_x86_64
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target)  {
+  femit_x86_64(cg_context, I_LEA, MEMORY_TO_REGISTER,
+               REG_RBP, offset,
+               target);
+}
+
+/// Load the value of a global variable into a newly allocated register and return it.
+void codegen_load_global_into_x86_64
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target) {
+  femit_x86_64(cg_context, I_MOV, NAME_TO_REGISTER,
+      REG_RIP, name,
+      target);
+}
+
+/// Load the value of a local variable into a newly allocated register and return it.
+void codegen_load_local_into_x86_64
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target)  {
+  femit_x86_64(cg_context, I_MOV, MEMORY_TO_REGISTER,
+      REG_RBP, offset,
+      target);
+}
+
+/// Store a global variable.
+void codegen_store_global_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ const char *name) {
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_NAME,
+               source, REG_RIP, name);
+}
+
+/// Store a local variable.
+void codegen_store_local_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ long long int offset) {
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_MEMORY,
+               source, REG_RBP, offset);
+}
+
+/// Store data in the memory pointed to by the given address.
+void codegen_store_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ RegisterDescriptor address) {
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_MEMORY, source, address, 0);
+}
+
+/// Add an immediate value to a register.
+void codegen_add_immediate_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ long long int immediate) {
+  femit_x86_64(cg_context, I_ADD, IMMEDIATE_TO_REGISTER,
+               immediate, reg);
+}
+
+/// Branch to a label if a register is zero.
+void codegen_branch_if_zero_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ const char *label) {
+  femit_x86_64(cg_context, I_TEST, REGISTER_TO_REGISTER, reg, reg);
+  femit_x86_64(cg_context, I_JCC, JUMP_TYPE_Z, label);
+}
+
+/// Branch to a label.
+void codegen_branch_x86_64
+(CodegenContext *cg_context,
+ const char *label) {
+  femit_x86_64(cg_context, I_JMP, NAME, label);
+}
+
+/// Copy a register to another register.
+void codegen_copy_register_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor src,
+ RegisterDescriptor dest) {
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, src, dest);
+}
+
+/// Zero out a register.
+void codegen_zero_register_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor reg) {
+  femit_x86_64(cg_context, I_XOR, REGISTER_TO_REGISTER, reg, reg);
+}
+
+/// Generate a comparison between two registers.
+RegisterDescriptor codegen_comparison_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ enum ComparisonType type,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  ASSERT(type < COMPARE_COUNT, "Invalid comparison type");
+  RegisterDescriptor result = register_allocate(cg_context);
+
+  // Zero out result register.
+  femit_x86_64(cg_context, I_XOR, REGISTER_TO_REGISTER, result, result);
+
+  // Perform the comparison.
+  femit_x86_64(cg_context, I_CMP, REGISTER_TO_REGISTER, rhs, lhs);
+  femit_x86_64(cg_context, I_SETCC, type, result);
+
+  if (mode == CODEGEN_CLOBBER_OPERANDS) {
+    register_deallocate(cg_context, lhs);
+    register_deallocate(cg_context, rhs);
+  }
+
+  return result;
+}
+
+/// Add two registers together.
+RegisterDescriptor codegen_add_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  if (mode == CODEGEN_CLOBBER_OPERANDS) {
+    femit_x86_64(cg_context, I_ADD, REGISTER_TO_REGISTER, lhs, rhs);
+    register_deallocate(cg_context, lhs);
+    return rhs;
+  } else {
+    RegisterDescriptor result = register_allocate(cg_context);
+    femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, rhs, result);
+    femit_x86_64(cg_context, I_ADD, REGISTER_TO_REGISTER, lhs, result);
+    return result;
+  }
+}
+
+/// Subtract rhs from lhs.
+RegisterDescriptor codegen_subtract_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  if (mode == CODEGEN_CLOBBER_OPERANDS) {
+    femit_x86_64(cg_context, I_SUB, REGISTER_TO_REGISTER, rhs, lhs);
+    register_deallocate(cg_context, rhs);
+    return lhs;
+  } else {
+    RegisterDescriptor result = register_allocate(cg_context);
+    femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, lhs, result);
+    femit_x86_64(cg_context, I_SUB, REGISTER_TO_REGISTER, rhs, result);
+    return result;
+  }
+}
+
+/// Multiply two registers together.
+RegisterDescriptor codegen_multiply_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  if (mode == CODEGEN_CLOBBER_OPERANDS) {
+    femit_x86_64(cg_context, I_IMUL, REGISTER_TO_REGISTER, lhs, rhs);
+    register_deallocate(cg_context, lhs);
+    return rhs;
+  } else {
+    RegisterDescriptor result = register_allocate(cg_context);
+    femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, rhs, result);
+    femit_x86_64(cg_context, I_IMUL, REGISTER_TO_REGISTER, lhs, result);
+    return result;
+  }
+}
+
+/// Divide lhs by rhs.
+RegisterDescriptor codegen_divide_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  return divmod(cg_context, mode, 1, lhs, rhs);
+}
+
+/// Modulo lhs by rhs.
+RegisterDescriptor codegen_modulo_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  return divmod(cg_context, mode, 0, lhs, rhs);
+}
+
+/// Shift lhs to the left by rhs.
+RegisterDescriptor codegen_shift_left_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  return shift(cg_context, mode, I_SAL, lhs, rhs);
+}
+
+/// Shift lhs to the right by rhs (arithmetic).
+RegisterDescriptor codegen_shift_right_arithmetic_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs) {
+  return shift(cg_context, mode, I_SAR, lhs, rhs);
+}
+
+/// Allocate space on the stack.
+void codegen_alloca_x86_64(CodegenContext *cg_context, long long int size) {
+  femit_x86_64(cg_context, I_SUB, IMMEDIATE_TO_REGISTER, size, REG_RSP);
+}
+
+/// Emit the function prologue.
+void codegen_prologue_x86_64(CodegenContext *cg_context) {
+  femit_x86_64(cg_context, I_PUSH, REGISTER, REG_RBP);
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, REG_RSP, REG_RBP);
+  femit_x86_64(cg_context, I_SUB, IMMEDIATE_TO_REGISTER, -cg_context->locals_offset, REG_RSP);
+}
+
+/// Emit the function epilogue.
+void codegen_epilogue_x86_64(CodegenContext *cg_context) {
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, REG_RBP, REG_RSP);
+  femit_x86_64(cg_context, I_POP, REGISTER, REG_RBP);
+  femit_x86_64(cg_context, I_RET);
+}
+
+/// Set the return value of a function.
+void codegen_set_return_value_x86_64(CodegenContext *cg_context, RegisterDescriptor value) {
+  femit_x86_64(cg_context, I_MOV, REGISTER_TO_REGISTER, value, REG_RAX);
+}
+
+/// Emit the entry point of the program.
+void codegen_entry_point_x86_64(CodegenContext *cg_context) {
+  fprintf(cg_context->code,
+      ".section .text\n"
+      ".global main\n"
+      "main:\n");
+  codegen_prologue_x86_64(cg_context);
+}

--- a/src/codegen/x86_64/arch_x86_64.c
+++ b/src/codegen/x86_64/arch_x86_64.c
@@ -1,5 +1,4 @@
-#include "arch_x86_64.h"
-
+#include <codegen/x86_64/arch_x86_64.h>
 #include <codegen.h>
 #include <error.h>
 #include <inttypes.h>

--- a/src/codegen/x86_64/arch_x86_64.h
+++ b/src/codegen/x86_64/arch_x86_64.h
@@ -130,7 +130,6 @@ void codegen_zero_register_x86_64
 /// Generate a comparison between two registers.
 RegisterDescriptor codegen_comparison_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  enum ComparisonType type,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
@@ -138,49 +137,42 @@ RegisterDescriptor codegen_comparison_x86_64
 /// Add two registers together.
 RegisterDescriptor codegen_add_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Subtract rhs from lhs.
 RegisterDescriptor codegen_subtract_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Multiply two registers together.
 RegisterDescriptor codegen_multiply_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Divide lhs by rhs.
 RegisterDescriptor codegen_divide_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Modulo lhs by rhs.
 RegisterDescriptor codegen_modulo_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Shift lhs to the left by rhs.
 RegisterDescriptor codegen_shift_left_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 
 /// Shift lhs to the right by rhs (arithmetic).
 RegisterDescriptor codegen_shift_right_arithmetic_x86_64
 (CodegenContext *cg_context,
- enum CodegenBinaryOpMode mode,
  RegisterDescriptor lhs,
  RegisterDescriptor rhs);
 

--- a/src/codegen/x86_64/arch_x86_64.h
+++ b/src/codegen/x86_64/arch_x86_64.h
@@ -1,7 +1,7 @@
 #ifndef ARCH_X86_64_H
 #define ARCH_X86_64_H
 
-#include "../codegen_forward.h"
+#include <codegen/codegen_forward.h>
 
 /// This is used for defining lookup tables etc. and
 /// ensures that the registers are always in the correct

--- a/src/codegen/x86_64/arch_x86_64.h
+++ b/src/codegen/x86_64/arch_x86_64.h
@@ -1,0 +1,203 @@
+#ifndef ARCH_X86_64_H
+#define ARCH_X86_64_H
+
+#include "../codegen_forward.h"
+
+/// This is used for defining lookup tables etc. and
+/// ensures that the registers are always in the correct
+/// order
+#define FOR_ALL_X86_64_REGISTERS(F)     \
+  F(RAX, "rax", "eax", "ax", "al")      \
+  F(RBX, "rbx", "ebx", "bx", "bl")      \
+  F(RCX, "rcx", "ecx", "cx", "cl")      \
+  F(RDX, "rdx", "edx", "dx", "dl")      \
+  F(R8,  "r8", "r8d", "r8w", "r8b")     \
+  F(R9,  "r9", "r9d", "r9w", "r9b")     \
+  F(R10, "r10", "r10d", "r10w", "r10b") \
+  F(R11, "r11", "r11d", "r11w", "r11b") \
+  F(R12, "r12", "r12d", "r12w", "r12b") \
+  F(R13, "r13", "r13d", "r13w", "r13b") \
+  F(R14, "r14", "r14d", "r14w", "r14b") \
+  F(R15, "r15", "r15d", "r15w", "r15b") \
+  F(RSI, "rsi", "esi", "si", "sil")     \
+  F(RDI, "rdi", "edi", "di", "dil")     \
+  F(RBP, "rbp", "ebp", "bp", "bpl")     \
+  F(RSP, "rsp", "esp", "sp", "spl")     \
+  F(RIP, "rip", "eip", "ip", "ipl")
+
+/// Context allocation/deallocation
+CodegenContext *codegen_context_x86_64_mswin_create(CodegenContext *parent);
+void codegen_context_x86_64_mswin_free(CodegenContext *ctx);
+
+/// Save state before a function call.
+void codegen_prepare_call_x86_64(CodegenContext *cg_context);
+
+/// Add an argument to the current function call.
+void codegen_add_external_function_arg_x86_64(CodegenContext *cg_context, RegisterDescriptor arg);
+
+/// Add an argument to the current function call.
+void codegen_add_internal_function_arg_x86_64(CodegenContext *cg_context, RegisterDescriptor arg);
+
+/// Call an external function. Returns the register containing the return value.
+RegisterDescriptor codegen_perform_external_call_x86_64
+(CodegenContext *cg_context,
+ const char* function_name);
+
+/// Call an internal function. Return the register containing the return value.
+RegisterDescriptor codegen_perform_internal_call_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor function);
+
+/// Clean up after a function call.
+void codegen_cleanup_call_x86_64(CodegenContext *cg_context);
+
+/// Load the address of a global variable into a register.
+void codegen_load_global_address_into_x86_64
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target);
+
+/// Load the address of a local variable into a register.
+void codegen_load_local_address_into_x86_64
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target);
+
+
+/// Load the value of a global variable into a register.
+void codegen_load_global_into_x86_64
+(CodegenContext *cg_context,
+ const char *name,
+ RegisterDescriptor target);
+
+/// Load the value of a local variable into a register.
+void codegen_load_local_into_x86_64
+(CodegenContext *cg_context,
+ long long int offset,
+ RegisterDescriptor target);
+
+/// Store a global variable.
+void codegen_store_global_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ const char *name);
+
+/// Store a local variable.
+void codegen_store_local_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ long long int offset);
+
+/// Store data in the memory pointed to by the given address.
+void codegen_store_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor source,
+ RegisterDescriptor address);
+
+/// Load an immediate value into a new register.
+RegisterDescriptor codegen_load_immediate_x86_64
+(CodegenContext *cg_context,
+ long long int immediate);
+
+/// Add an immediate value to a register.
+void codegen_add_immediate_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ long long int immediate);
+
+/// Branch to a label if a register is zero.
+void codegen_branch_if_zero_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor reg,
+ const char *label);
+
+/// Branch to a label.
+void codegen_branch_x86_64
+(CodegenContext *cg_context,
+ const char *label);
+
+/// Copy a register to another register.
+void codegen_copy_register_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor src,
+ RegisterDescriptor dest);
+
+/// Zero out a register.
+void codegen_zero_register_x86_64
+(CodegenContext *cg_context,
+ RegisterDescriptor reg);
+
+/// Generate a comparison between two registers.
+RegisterDescriptor codegen_comparison_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ enum ComparisonType type,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Add two registers together.
+RegisterDescriptor codegen_add_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Subtract rhs from lhs.
+RegisterDescriptor codegen_subtract_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Multiply two registers together.
+RegisterDescriptor codegen_multiply_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Divide lhs by rhs.
+RegisterDescriptor codegen_divide_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Modulo lhs by rhs.
+RegisterDescriptor codegen_modulo_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Shift lhs to the left by rhs.
+RegisterDescriptor codegen_shift_left_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Shift lhs to the right by rhs (arithmetic).
+RegisterDescriptor codegen_shift_right_arithmetic_x86_64
+(CodegenContext *cg_context,
+ enum CodegenBinaryOpMode mode,
+ RegisterDescriptor lhs,
+ RegisterDescriptor rhs);
+
+/// Allocate space on the stack.
+void codegen_alloca_x86_64(CodegenContext *cg_context, long long int size);
+
+
+/// Emit the function prologue.
+void codegen_prologue_x86_64(CodegenContext *cg_context);
+
+/// Emit the function epilogue.
+void codegen_epilogue_x86_64(CodegenContext *cg_context);
+
+/// Set the return value of a function.
+void codegen_set_return_value_x86_64(CodegenContext *cg_context, RegisterDescriptor reg);
+
+/// Emit the entry point of the program.
+void codegen_entry_point_x86_64(CodegenContext *cg_context);
+
+#endif // ARCH_X86_64_H

--- a/src/error.h
+++ b/src/error.h
@@ -31,7 +31,7 @@ extern Error ok;
 #  define FORMAT(...) __attribute__((format(__VA_ARGS__)))
 #  define PRETTY_FUNCTION __PRETTY_FUNCTION__
 #else
-#  define NORETURN
+#  define NORETURN __declspec(noreturn)
 #  define FORMAT(...)
 #  define PRETTY_FUNCTION __FUNCSIG__
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -180,7 +180,7 @@ int main(int argc, char **argv) {
   }
 
   char *output_filepath = output_filepath_index == -1 ? "code.S" : argv[output_filepath_index];
-  err = codegen_program(output_format, output_calling_convention, output_filepath, context, program);
+  err = codegen(output_format, output_calling_convention, output_filepath, context, program);
   if (err.type) {
     print_error(err);
     return 3;


### PR DESCRIPTION
This pr is a *major* refactor of the backend. All x86_64-specific code is now in a separate file. The basic idea is that codegen.c calls into functions defined in codegen_platform.c, and those functions dispatch between the different architectures. There are a lot of function signatures, and if we want to add more target architectures, I'd probably recommend introducing some macros so that we don't have to repeat all the signatures in every target header.

The codegen_forward.h header contains forward declarations and enumerations and was introduced to avoid circular header dependencies; it is included in every file that is part of the backend but does not include any headers itself.

I've also added a switch to enable intel syntax instead of at&t.

This summary is rather terse, but if I were to attempt to explain every last change that this pr introduces, then this message would probably be the size of a small novel. The code speaks for itself... I hope.

And yes, it works with MSVC.

GAS-specific directives, labels, etc. are still in the main codegen file and should probably be extracted as well.