### PR TITLE
[FEATURE] Array Literals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,15 +55,15 @@
   - [x] Type info in codegen/IR.
   - [ ] Backend: Handle size/alignment requirements
   - [x] Use eax, ax, al, etc.
-  - [ ] Actually implementing casts.
-    - [ ] During codegen, we should actually output `zext`/`sext` if needed. Otherwise truncation is automatic.
+  - [x] Actually implementing casts.
+    - [x] During codegen, we should actually output `zext`/`sext` if needed. Otherwise truncation is automatic.
   - [ ] Update IR parser
-  - [ ] Operators (unary and binary) need to pick return type instead of strictly returning `integer`
+  - [x] Operators (unary and binary) need to pick return type instead of strictly returning `integer`
 - [ ] Arrays
-  - [ ] Semantic analysis for static arrays.
-  - [ ] Codegen
-  - [ ] How do we implement reassigning arrays? Libc `memcpy()` or some builtin variant?
-    - [ ] Use compiler explorer to see how GCC does it for ‘inspiration’.
+  - [x] Semantic analysis for static arrays.
+  - [x] Codegen
+  - [x] How do we implement reassigning arrays? Libc `memcpy()` or some builtin variant?
+    - [x] Use compiler explorer to see how GCC does it for ‘inspiration’.
   - [ ] Arrays as function parameters.
     - [ ] Currently, only register-based parameters are really supported; we need to implement stack parameters for non-integer types.
   - [ ] Returning arrays from functions.
@@ -80,11 +80,11 @@
   - [x] Backend.
 - [ ] Structs
   - [ ] Order-independent types.
-  - [ ] Structs in the AST.
-  - [ ] Struct declarations.
-  - [ ] Semantic analysis for structs.
-  - [ ] Codegen for structs.
-  - [ ] `type` keyword in the parser/grammar.
+  - [x] Structs in the AST.
+  - [x] Struct declarations.
+  - [x] Semantic analysis for structs.
+  - [x] Codegen for structs.
+  - [x] `type` keyword in the parser/grammar.
   - [ ] Make sure nested structs work.
   - [ ] Arbitrary compile-time struct literals.
     - [ ] Syntax?

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
   - [x] Vector macros should be snake_case.
   - [ ] LLVM_PATH env var or something in CMakeLists.txt rather than `find_package()`?
   - [ ] `integer`/`byte`/`void` should be keywords (and terminals in the grammar).
+  - [ ] `i8/u8/i16/u16/i32/u32/i64/u64`
   - [ ] Early `return`
     - [ ] Parsing
     - [ ] Return block in the IR

--- a/src/ast.c
+++ b/src/ast.c
@@ -354,6 +354,24 @@ Node *ast_make_string_literal(
   return node;
 }
 
+/// Create a new compound literal.
+Node *ast_make_compound_literal(
+    AST *ast,
+    loc source_location
+) {
+  Node *node = mknode(ast, NODE_LITERAL, source_location);
+  node->literal.type = TK_LBRACK;
+  vector_clear(node->literal.compound);
+  return node;
+}
+/// Add a node to an existing compound literal.
+void ast_add_to_compound_literal(
+    Node *compound,
+    Node *node
+) {
+  vector_push(compound->literal.compound, node);
+}
+
 /// Create a new variable reference.
 Node *ast_make_variable_reference(
     AST *ast,
@@ -852,6 +870,20 @@ void ast_print_node_internal(
           fprint(file, "%31Literal %35<%u> %33%Z %36string\n",
             node->source_location.start,
             (usz) node->literal.string_index);
+        } break;
+
+        case TK_LBRACK: {
+          if (node->type)
+            fprint(file, "%31Literal %35<%u> %31: %T\n",
+                   node->source_location.start,
+                   node->type);
+          else
+            fprint(file, "%31Literal %35<%u> %35%Z %36array\n",
+                   node->source_location.start,
+                   (usz) node->literal.compound.size);
+
+          ast_print_children(file, logical_parent, node, &node->literal.compound, leading_text);
+
         } break;
 
         default: TODO("Print literal of type %d", node->literal.type);

--- a/src/ast.h
+++ b/src/ast.h
@@ -238,6 +238,7 @@ typedef struct NodeLiteral {
   union {
     u64 integer;
     usz string_index;
+    Nodes compound;
   };
 } NodeLiteral;
 
@@ -525,6 +526,17 @@ Node *ast_make_string_literal(
     AST *ast,
     loc source_location,
     span string
+);
+
+/// Create a new compound literal.
+Node *ast_make_compound_literal(
+    AST *ast,
+    loc source_location
+);
+/// Add a node to an existing compound literal.
+void ast_add_to_compound_literal(
+    Node *compound,
+    Node *node
 );
 
 /// Create a new variable reference.

--- a/src/codegen/x86_64/arch_x86_64.c
+++ b/src/codegen/x86_64/arch_x86_64.c
@@ -1443,7 +1443,6 @@ static void emit_memcpy(CodegenContext *context, IRInstruction *to_, IRInstructi
     // Switch type to reflect storing 1 byte.
     from->type = ast_make_type_pointer(context->ast, t_byte->source_location, t_byte);
     to->type = ast_make_type_pointer(context->ast, t_byte->source_location, t_byte);
-
     emit_memcpy_impl(context, to, from, byte_size, 1, insert_before_this);
   }
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1139,6 +1139,17 @@ static Node *parse_expr_with_precedence(Parser *p, isz current_precedence) {
       lhs = ast_make_string_literal(p->ast, p->tok.source_location, as_span(p->tok.text));
       next_token(p);
       break;
+    case TK_LBRACK: {
+      lhs = ast_make_compound_literal(p->ast, p->tok.source_location);
+      next_token(p); //> Yeet "["
+      while (p->tok.type != TK_RBRACK) {
+        Node *expr = parse_expr(p);
+        vector_push(lhs->literal.compound, expr);
+        if (p->tok.type == TK_COMMA) next_token(p);
+      }
+      lhs->source_location.end = p->tok.source_location.end - 1;
+      consume(p, TK_RBRACK);
+    } break;
     case TK_LPAREN:
       next_token(p); //> Yeet "("
       lhs = parse_expr(p);

--- a/src/typechecker.c
+++ b/src/typechecker.c
@@ -182,6 +182,18 @@ NODISCARD static isz convertible_score(Type *to_type, Type *from_type) {
   /// Integer literals are convertible to any integer type.
   if (from == t_integer_literal && to_is_int) return 1;
 
+  // An array type is convertible to another array type if `from` size
+  // is less than or equal to `to` size, as well as the element type
+  // being convertible.
+  if (from->kind == TYPE_ARRAY && to->kind == TYPE_ARRAY) {
+    if (from->array.size > to->array.size)
+      return -1;
+    if (convertible_score(to->array.of, from->array.of) == -1)
+      return -1;
+
+    return 1;
+  }
+
   /// Otherwise, the types are not convertible.
   return -1;
 }

--- a/src/typechecker.c
+++ b/src/typechecker.c
@@ -907,6 +907,17 @@ NODISCARD bool typecheck_expression(AST *ast, Node *expr) {
           if (expr->type == t_integer_literal) expr->type = t_integer;
         } else if (!convertible(expr->type, expr->declaration.init->type))
           ERR_NOT_CONVERTIBLE(expr->declaration.init->source_location, expr->type, expr->declaration.init->type);
+
+        if (expr->declaration.init->type == t_integer_literal)
+          expr->declaration.init->type = expr->type;
+        else if (expr->declaration.init->type->kind == TYPE_ARRAY &&
+                 expr->declaration.init->type->array.of == t_integer_literal) {
+          expr->declaration.init->type->array.of = expr->type->array.of;
+          foreach_ptr (Node *, node, expr->declaration.init->literal.compound) {
+            node->type = expr->type->array.of;
+          }
+        }
+
       } else if (!expr->type) ERR(expr->source_location, "Cannot infer type of declaration without initialiser");
 
       if (!typecheck_type(ast, expr->type)) return false;

--- a/src/typechecker.c
+++ b/src/typechecker.c
@@ -188,10 +188,7 @@ NODISCARD static isz convertible_score(Type *to_type, Type *from_type) {
   if (from->kind == TYPE_ARRAY && to->kind == TYPE_ARRAY) {
     if (from->array.size > to->array.size)
       return -1;
-    if (convertible_score(to->array.of, from->array.of) == -1)
-      return -1;
-
-    return 1;
+    return convertible_score(to->array.of, from->array.of);
   }
 
   /// Otherwise, the types are not convertible.

--- a/tst/tests/array_literals.int
+++ b/tst/tests/array_literals.int
@@ -1,4 +1,3 @@
-; SKIP
 ; 69
 
 foo : integer[2] = [34  35]

--- a/tst/tests/copy_arrays.int
+++ b/tst/tests/copy_arrays.int
@@ -4,5 +4,5 @@ a : integer[2]
 @a[0] := 69
 
 b : integer[2]
-b := a ;; copy entire array a into array b
+b := a
 @b[0]


### PR DESCRIPTION
Basically, it's annoying to have to do the following:
```lisp
foo : integer[2]
@foo[0] = 34
@foo[1] = 35
@foo[0] + @foo[1]
```

It would be much better, and much more concise, to simply write
```lisp
foo : integer[2] = [34  35]
@foo[0] + @foo[1]
```

This PR implements that.

KNOWN ISSUES (want to fix):
- Byte arrays muck things up because x86_64 backend can't find a register that's 3, 5,6,7 bytes large.
- It's very inefficient, because compile-time-known array literals are not even checked for; all of them are emitted as runtime expressions. This means `[34 35]` makes a copy on the stack which is then copied into the final array... It gets messy quickly, as the x86_64 backend lowers loads/stores into even more stack allocations and copies.