### PR TITLE
Format things in strings

### DIFF
--- a/editor/int/syntax/int.vim
+++ b/editor/int/syntax/int.vim
@@ -19,8 +19,11 @@ syntax region intString start="\"" skip="\\\"" end="\"" contains=intSpecial,intF
 syntax keyword intPrimitiveTypes
   \ integer
   \ void
+  \ byte
 
 syntax keyword intKeywords
+  \ ext
+  \ type
   \ if
   \ else
   \ ext

--- a/editor/int/syntax/int.vim
+++ b/editor/int/syntax/int.vim
@@ -8,7 +8,13 @@ syntax region intCommentLine start=";" end="$" display contains=intTodo
 
 syntax match intSpecial contained "\\[nr\\\"\'t]" display
 
-syntax region intString start="\"" skip="\\\"" end="\"" contains=intSpecial
+syntax match intFormat contained "%[csSCdiuDIUZzxXpbTF%m]" display
+" TODO: Not sure about these
+" syntax match intFormat contained "%\d" display
+" syntax match intFormat contained "%\d\d" display
+" syntax match intFormat contained "%\d\d\d" display
+
+syntax region intString start="\"" skip="\\\"" end="\"" contains=intSpecial,intFormat
 
 syntax keyword intPrimitiveTypes
   \ integer
@@ -29,6 +35,7 @@ highlight default link intNumber         Number
 highlight default link intCommentLine    Comment
 highlight default link intOperators      Operator
 highlight default link intSpecial        Special
+highlight default link intFormat         Special
 highlight default link intString         String
 
 let b:current_syntax = 'int'

--- a/editor/int/syntax/int.vim
+++ b/editor/int/syntax/int.vim
@@ -24,9 +24,14 @@ syntax keyword intPrimitiveTypes
 syntax keyword intKeywords
   \ ext
   \ type
+
+syntax keyword intRepeat
+  \ for
+  \ while
+
+syntax keyword intConditional
   \ if
   \ else
-  \ ext
 
 syntax match intOperators "?\|+\|-\|\*\|:\|,\|<\|>\|&\||\|!\|\~\|%\|=\|\.\|/\(/\|*\)\@!"
 
@@ -34,6 +39,8 @@ syntax match intNumber "\v<\d+>"
 
 highlight default link intPrimitiveTypes Type
 highlight default link intKeywords       Keyword
+highlight default link intRepeat         Repeat
+highlight default link intConditional    Conditional
 highlight default link intNumber         Number
 highlight default link intCommentLine    Comment
 highlight default link intOperators      Operator


### PR DESCRIPTION
I don't know how `%X`, `%BXX` works, so I commented these out in syntax file.

Tested in `VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Oct 01 2021 01:51:08)`.