### PR TITLE
[Feature] Syscalls

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -23,6 +23,7 @@ enum NodeKind {
   NODE_UNARY,
   NODE_LITERAL,
   NODE_FUNCTION_REFERENCE,
+  NODE_INTRINSIC_CALL,
   NODE_MODULE_REFERENCE,
   NODE_VARIABLE_REFERENCE,
   NODE_STRUCTURE_DECLARATION,
@@ -134,6 +135,12 @@ enum SymbolKind {
   SYM_FUNCTION,
   SYM_TYPE,
   SYM_COUNT
+};
+
+/// Intrinsic functions.
+enum IntrinsicKind {
+    INTRINSIC_BUILTIN_SYSCALL,
+    INTRINSIC_COUNT,
 };
 
 /// ===========================================================================
@@ -252,6 +259,7 @@ typedef struct NodeBlock {
 typedef struct NodeCall {
   Node *callee;
   Nodes arguments;
+  enum IntrinsicKind intrinsic; /// Only used by intrinsic calls.
 } NodeCall;
 
 /// Typecast.

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -59,6 +59,10 @@ struct CodegenContext {
   CodegenTarget target;
   CodegenCallingConvention call_convention;
 
+  /// Whether there was an error during codegen.
+  /// TODO: Move target information up to Sema. Keep this here regardless tho.
+  bool has_err;
+
   /// FFI type sizes in BITS (!)
   struct {
     u8 cchar_size;

--- a/src/codegen/codegen_forward.h
+++ b/src/codegen/codegen_forward.h
@@ -110,6 +110,7 @@ enum ComparisonType {
 #define ALL_IR_INSTRUCTION_TYPES(F)                              \
   F(IMMEDIATE)                                                   \
   F(CALL)                                                        \
+  F(INTRINSIC)                                                   \
   F(LOAD)                                                        \
                                                                  \
   F(RETURN)                                                      \

--- a/src/codegen/dom.c
+++ b/src/codegen/dom.c
@@ -18,7 +18,7 @@ static BlockVector collect_reachable_blocks(IRBlock *block, IRBlock *ignore) {
     IRBlock *b = vector_pop(dfs_stack);
     if (b == ignore) continue;
 
-    STATIC_ASSERT(IR_COUNT == 38, "Handle all branch types");
+    STATIC_ASSERT(IR_COUNT == 39, "Handle all branch types");
     IRInstruction *i = b->instructions.last;
     switch (i->kind) {
       default: break;

--- a/src/codegen/intermediate_representation.h
+++ b/src/codegen/intermediate_representation.h
@@ -55,6 +55,7 @@ typedef struct IRCall {
     IRInstruction *callee_instruction;
     IRFunction *callee_function;
   };
+  enum IntrinsicKind intrinsic; /// Only used by intrinsic calls.
   bool is_indirect : 1;
   bool tail_call : 1;
 } IRCall;
@@ -395,5 +396,12 @@ IRInstruction *ir_get_literal_string(CodegenContext *context, usz string_index);
 
 /// Get the function type of a call.
 Type* ir_call_get_callee_type(IRInstruction* inst);
+
+/// Create an intrinsic instruction.
+///
+/// Note: Prefer to lower intrinsics to other IR instructions. This
+/// is only for instructions that need to be lowered to special ASM
+/// instructions or depend on late compile-time constants.
+IRInstruction *ir_intrinsic(CodegenContext *context, Type *t, enum IntrinsicKind intrinsic);
 
 #endif /* INTERMEDIATE_REPRESENTATION_H */

--- a/src/codegen/register_allocation.c
+++ b/src/codegen/register_allocation.c
@@ -53,7 +53,7 @@ static void vreg_vector_remove_element(VRegVector *vregs, usz vreg_value) {
 
 /// Return non-zero iff given instruction needs a register.
 static bool needs_register(IRInstruction *instruction) {
-  STATIC_ASSERT(IR_COUNT == 38, "Exhaustively handle all instruction types");
+  STATIC_ASSERT(IR_COUNT == 39, "Exhaustively handle all instruction types");
   ASSERT(instruction);
   switch (instruction->kind) {
     case IR_LOAD:
@@ -61,6 +61,7 @@ static bool needs_register(IRInstruction *instruction) {
     case IR_COPY:
     case IR_IMMEDIATE:
     case IR_CALL:
+    case IR_INTRINSIC:
     case IR_REGISTER:
     case IR_NOT:
     case IR_ZERO_EXTEND:

--- a/src/codegen/x86_64/arch_x86_64_isel.c
+++ b/src/codegen/x86_64/arch_x86_64_isel.c
@@ -11,7 +11,7 @@
 #include <utils.h>
 
 const char *mir_x86_64_opcode_mnemonic(uint32_t opcode) {
-  STATIC_ASSERT(MX64_COUNT == 29, "Exhaustive handling of x86_64 opcodes (string conversion)");
+  STATIC_ASSERT(MX64_COUNT == 30, "Exhaustive handling of x86_64 opcodes (string conversion)");
   //ASSERT(opcode >= MIR_ARCH_START && opcode < MX64_END, "Opcode is not x86_64 opcode");
   switch ((MIROpcodex86_64)opcode) {
   case MX64_START: return "!start";
@@ -36,6 +36,7 @@ const char *mir_x86_64_opcode_mnemonic(uint32_t opcode) {
   case MX64_PUSH: return "push";
   case MX64_POP: return "pop";
   case MX64_CALL: return "call";
+  case MX64_SYSCALL: return "syscall";
   case MX64_JMP: return "jmp";
   case MX64_RET: return "ret";
   case MX64_JCC: return "jcc";
@@ -52,7 +53,7 @@ const char *mir_x86_64_opcode_mnemonic(uint32_t opcode) {
 
 static MIROpcodex86_64 gmir_binop_to_x64(MIROpcodeCommon opcode) {
   DBGASSERT(opcode < MIR_COUNT, "Argument is meant to be a general MIR instruction opcode.");
-  STATIC_ASSERT(MIR_COUNT == 38, "Exhaustive handling of binary operator machine instruction opcodes for x86_64 backend");
+  STATIC_ASSERT(MIR_COUNT == 39, "Exhaustive handling of binary operator machine instruction opcodes for x86_64 backend");
   switch (opcode) {
   case MIR_ADD: return MX64_ADD;
   case MIR_SUB: return MX64_SUB;
@@ -109,7 +110,7 @@ static void divmod(CodegenContext *context, IRInstruction *inst) {
 */
 
 static void emit_instruction(CodegenContext *context, IRInstruction *inst) {
-  STATIC_ASSERT(IR_COUNT == 38, "Handle all IR instructions");
+  STATIC_ASSERT(IR_COUNT == 39, "Handle all IR instructions");
 
   if (annotate_code) {
     // TODO: Base comment syntax on dialect or smth.

--- a/src/codegen/x86_64/arch_x86_64_isel.h
+++ b/src/codegen/x86_64/arch_x86_64_isel.h
@@ -34,6 +34,7 @@
   X(POP)                                        \
   /* Control flow */                            \
   X(CALL)                                       \
+  X(SYSCALL)                                    \
   X(JMP)                                        \
   X(RET)                                        \
   X(JCC)                                        \

--- a/src/codegen/x86_64/arch_x86_64_tgt_assembly.c
+++ b/src/codegen/x86_64/arch_x86_64_tgt_assembly.c
@@ -21,7 +21,7 @@ static const char *setcc_suffixes_x86_64[COMPARE_COUNT] = {
 };
 
 static const char *instruction_mnemonic(CodegenContext *context, MIROpcodex86_64 instruction) {
-  STATIC_ASSERT(MX64_COUNT == 29, "ERROR: instruction_mnemonic() must exhaustively handle all instructions.");
+  STATIC_ASSERT(MX64_COUNT == 30, "ERROR: instruction_mnemonic() must exhaustively handle all instructions.");
   // x86_64 instructions that aren't different across syntaxes can go here!
   switch (instruction) {
   default: break;
@@ -42,6 +42,7 @@ static const char *instruction_mnemonic(CodegenContext *context, MIROpcodex86_64
   case MX64_XOR: return "xor";
   case MX64_CMP: return "cmp";
   case MX64_CALL: return "call";
+  case MX64_SYSCALL: return "syscall";
   case MX64_JMP: return "jmp";
   case MX64_RET: return "ret";
   case MX64_MOV: return "mov";
@@ -473,6 +474,7 @@ static void femit_jcc(CodegenContext *context, IndirectJumpType type, const char
 static void femit_none(CodegenContext *context, MIROpcodex86_64 instruction) {
   switch (instruction) {
     case MX64_RET:
+    case MX64_SYSCALL:
     case MX64_CWD:
     case MX64_CDQ:
     case MX64_CQO: {
@@ -982,6 +984,7 @@ void emit_x86_64_assembly(CodegenContext *context, MIRFunctionVector machine_ins
           }
         } break;
 
+        case MX64_SYSCALL: FALLTHROUGH;
         case MX64_CWD: FALLTHROUGH;
         case MX64_CDQ: FALLTHROUGH;
         case MX64_CQO: {

--- a/src/codegen/x86_64/arch_x86_64_tgt_generic_object.c
+++ b/src/codegen/x86_64/arch_x86_64_tgt_generic_object.c
@@ -2161,6 +2161,10 @@ static void mcode_none(CodegenContext *context, MIROpcodex86_64 inst) {
     mcode_2(context->object, rexw, op);
   } break;
 
+  case MX64_SYSCALL: {
+    mcode_2(context->object, 0x0F, 0x05);
+  } break;
+
   default:
     ICE("ERROR: mcode_none(): Unsupported instruction %d (%s)", inst, mir_x86_64_opcode_mnemonic(inst));
   }
@@ -2679,6 +2683,7 @@ void emit_x86_64_generic_object(CodegenContext *context, MIRFunctionVector machi
           }
         } break;
 
+        case MX64_SYSCALL: FALLTHROUGH;
         case MX64_CWD: FALLTHROUGH;
         case MX64_CDQ: FALLTHROUGH;
         case MX64_CQO: {

--- a/src/opt.c
+++ b/src/opt.c
@@ -55,7 +55,7 @@ static bool power_of_two(u64 value) {
 }
 
 static bool has_side_effects(IRInstruction *i) {
-  STATIC_ASSERT(IR_COUNT == 38, "Handle all instructions");
+  STATIC_ASSERT(IR_COUNT == 39, "Handle all instructions");
   switch (i->kind) {
     /// These do NOT have side effects.
     case IR_IMMEDIATE:
@@ -681,7 +681,7 @@ static bool opt_jump_threading(IRFunction *f, DominatorInfo *info) {
       list_foreach (b2, f->blocks) {
         if (b == b2) continue;
 
-        STATIC_ASSERT(IR_COUNT == 38, "Handle all branch instructions");
+        STATIC_ASSERT(IR_COUNT == 39, "Handle all branch instructions");
         IRInstruction *branch = b2->instructions.last;
         if (branch->kind == IR_BRANCH && branch->destination_block == b) {
           branch->destination_block = last->destination_block;

--- a/tst/tests/sys-write.int
+++ b/tst/tests/sys-write.int
@@ -1,0 +1,4 @@
+;; 38
+;; This message was printed by a syscall
+
+__builtin_syscall(1, 1, "This message was printed by a syscall\n"[0], 38)


### PR DESCRIPTION
This adds a `__builtin_syscall()` intrinsic function that can be used to perform syscalls. Due to the fact that syscalls are not really used on Windows, this feature is currently only supported on X86_64 Linux (Sys V calling convention). Also added support for syscalls to the LLVM backend.