### PR TITLE
Fix a few small bugs in Intercept

### DIFF
--- a/include/intercept/ast.hh
+++ b/include/intercept/ast.hh
@@ -1188,7 +1188,7 @@ public:
           _value(std::move(value)),
           _expression(expr) {
         LCC_ASSERT(expr->ok());
-        expr->set_sema_done();
+        set_sema_done();
     }
 
     auto expr() const { return _expression; }

--- a/lib/intercept/ast.cc
+++ b/lib/intercept/ast.cc
@@ -364,7 +364,9 @@ auto intc::Type::strip_references() -> Type* {
 }
 
 bool intc::Type::Equal(const Type* a, const Type* b) {
+    if (a == b) return true;
     if (a->kind() != b->kind()) return false;
+    
     switch (a->kind()) {
         case Kind::Builtin: {
             auto ba = as<BuiltinType>(a);
@@ -410,6 +412,7 @@ bool intc::Type::Equal(const Type* a, const Type* b) {
         case Kind::Struct: {
             auto sa = as<StructType>(a);
             auto sb = as<StructType>(b);
+
             if (sa->decl() or sb->decl()) return false;
 
             /// Compare fields.

--- a/lib/intercept/parser.cc
+++ b/lib/intercept/parser.cc
@@ -799,7 +799,13 @@ auto intc::Parser::ParseFuncBody(bool is_extern) -> Result<std::pair<Expr*, Scop
     /// The body must either be a block expression or an equals sign
     /// followed by an expression.
     auto scope = sc.scope;
-    auto expr = Consume(Tk::Eq) ? ParseExpr() : ParseBlock(std::move(sc));
+    auto expr = ExprResult::Null();
+    if (Consume(Tk::Eq)) expr = ParseExpr();
+    else if (At(Tk::LBrace)) expr = ParseBlock(std::move(sc));
+
+    /// If the body isn't followed by either, it's not a valid function decleration
+    else Error("Function decleration should be followed by `=` and an expression or a block");
+
     if (expr.is_diag()) return expr.diag();
     return std::pair{*expr, scope};
 }

--- a/lib/intercept/parser.cc
+++ b/lib/intercept/parser.cc
@@ -803,8 +803,8 @@ auto intc::Parser::ParseFuncBody(bool is_extern) -> Result<std::pair<Expr*, Scop
     if (Consume(Tk::Eq)) expr = ParseExpr();
     else if (At(Tk::LBrace)) expr = ParseBlock(std::move(sc));
 
-    /// If the body isn't followed by either, it's not a valid function decleration
-    else Error("Function decleration should be followed by `=` and an expression or a block");
+    /// If the body isn't followed by either, it's not a valid function declaration
+    else Error("Function declaration should be followed by `=` and an expression or a block");
 
     if (expr.is_diag()) return expr.diag();
     return std::pair{*expr, scope};

--- a/lib/intercept/sema.cc
+++ b/lib/intercept/sema.cc
@@ -479,7 +479,7 @@ void intc::Sema::AnalyseFunctionBody(FuncDecl* decl) {
         else decl->body() = new (mod) ReturnExpr(*last, {});
     } else {
         if (auto block = cast<BlockExpr>(decl->body())) {
-            if (not is<ReturnExpr>(*block->last_expr()))
+            if (not block->children().size() or not is<ReturnExpr>(*block->last_expr()))
                 block->add(new (mod) ReturnExpr(nullptr, {}));
         } else {
             // TODO: If a function with void return type and a non-block body

--- a/lib/intercept/sema.cc
+++ b/lib/intercept/sema.cc
@@ -899,7 +899,7 @@ void intc::Sema::AnalyseBinary(BinaryExpr* b) {
             }
 
             /// If it is an integer, try to evaluate it for bounds checking.
-            if (auto arr = as<ArrayType>(ty); arr and arr->size()->ok()) {
+            if (auto arr = cast<ArrayType>(ty); arr and arr->size()->ok()) {
                 EvalResult res;
                 if (b->rhs()->evaluate(context, res, false)) {
                     if (res.as_i64() < 0 or res.as_i64() >= as<ConstantExpr>(arr->size())->value().as_i64())


### PR DESCRIPTION
- Fixes the error message for functions without a valid body aaed66d fixes #92
- Fixes a bug with empty void functions in sema fba2fb4
- Fixes a bug with constantexpr in sema not working properly f5ca143
- Fixes a bug, where you couldn't index pointers 9d27fba
- Fixes a bug, where types werent properly compared  5cfec40