### PR TITLE
Check if a register is a valid x86_64 register before printint it

### DIFF
--- a/include/lcc/codegen/x86_64.hh
+++ b/include/lcc/codegen/x86_64.hh
@@ -71,6 +71,7 @@ std::string opcode_to_string(usz opcode);
 std::string ToString(Opcode op);
 std::string ToString(RegisterId id);
 std::string ToString(RegisterId id, usz size);
+bool IsValidRegisterId(usz reg);
 
 } // namespace x86_64
 } // namespace lcc

--- a/lib/lcc/codegen/x86_64/assembly.cc
+++ b/lib/lcc/codegen/x86_64/assembly.cc
@@ -24,8 +24,8 @@ std::string block_name(std::string in) {
 
 std::string ToString(MFunction& function, MOperand op) {
     if (std::holds_alternative<MOperandRegister>(op)) {
-        // TODO: Assert that register id is one of the x86_64 register ids...
         MOperandRegister reg = std::get<MOperandRegister>(op);
+        LCC_ASSERT(IsValidRegisterId(reg.value), "Register with value '{}' is not a valid x86_64 register.", reg.value);
         return fmt::format("%{}", ToString(RegisterId(reg.value), reg.size));
     } else if (std::holds_alternative<MOperandImmediate>(op)) {
         return fmt::format("${}", std::get<MOperandImmediate>(op));
@@ -213,6 +213,10 @@ void emit_gnu_att_assembly(std::filesystem::path output_path, Module* module, co
     if (output_path == "-")
         fmt::print("{}", out);
     else File::WriteOrTerminate(out.data(), out.size(), output_path);
+}
+
+bool IsValidRegisterId(usz reg) {
+    return (reg == +RegisterId::RETURN) or (reg >= +RegisterId::RAX and reg <= +RegisterId::RIP);
 }
 
 } // namespace x86_64


### PR DESCRIPTION
Make sure the register value maps to a valid x86_64 register.