### PR TITLE
[Editor/Vim] Glint syntax update

### DIFF
--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -100,7 +100,7 @@ hi def link glintMacro              Macro
 hi def link glintMacroArgs          Function
 hi def link glintModule             Special
 hi def link glintImport             Special
-hi def link glintExportSymbol       Special
+hi def link glintExportSymbol       StorageClass
 hi def link glintModuleName         Function
 hi def link glintBuiltinFunc        Identifier
 hi def link glintDataTypes          Structure

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -42,7 +42,6 @@ syn keyword glintKeywords
   \ external
   \ return
   \ sizeof
-  \ supplant
   \ match
 
 syn keyword glintRepeat
@@ -79,6 +78,7 @@ syn keyword glintBuiltinFunc __builtin_syscall __builtin_line __builtin_filename
 syn keyword glintImport import nextgroup=glintModuleName skipwhite
 syn keyword glintModule module nextgroup=glintModuleName skipwhite
 syn keyword glintExportSymbol export
+syn keyword glintSupplant supplant
 
 " NOTE: Include semicolon at the end of line?
 syn match glintModuleName "\<[a-zA-Z0-9_]*" contained skipwhite
@@ -104,5 +104,6 @@ hi def link glintExportSymbol       StorageClass
 hi def link glintModuleName         Function
 hi def link glintBuiltinFunc        Identifier
 hi def link glintDataTypes          Structure
+hi def link glintSupplant           StorageClass
 
 let b:current_syntax = 'glint'

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -4,7 +4,7 @@ endif
 
 syn keyword glintTodo contained TODO FIXME XXX NOTE
 
-syn region glintCommentLine start=";" end="$" display contains=glintTodo
+syn region glintCommentLine start=";;" end="$" display contains=glintTodo
 
 syn region glintRawString start="'" end="'" display
 

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -32,13 +32,16 @@ syn keyword glintPrimitiveTypes
   \ uint
   \ void
 
+syn keyword glintDataTypes
+  \ struct
+  \ enum
+  \ sum
+
 syn keyword glintKeywords
   \ alignof
-  \ enum
   \ external
   \ return
   \ sizeof
-  \ struct
   \ supplant
   \ match
 
@@ -100,5 +103,6 @@ hi def link glintImport             Special
 hi def link glintExportSymbol       Special
 hi def link glintModuleName         Function
 hi def link glintBuiltinFunc        Identifier
+hi def link glintDataTypes          Structure
 
 let b:current_syntax = 'glint'


### PR DESCRIPTION
What was done:
- `struct`, `enum`, `sum` -> `Structure`
- `glintExportSymbol` -> `StorageClass`
- `supplant` -> `StorageClass`