### PR TITLE
[Editor/Vim] Update Vim syntax highlighting to match current version

### DIFF
--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -14,6 +14,8 @@ syn region glintString start="\"" skip="\\\"" end="\"" contains=glintSpecial
 syn keyword glintFFITypes
   \ cshort
   \ cushort
+  \ csize
+  \ cusize
   \ cint
   \ cuint
   \ clong

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -10,6 +10,7 @@ syn region glintRawString start="'" end="'" display
 
 syn match glintSpecial contained "\\[nr\\\"\'t]" display
 syn region glintString start="\"" skip="\\\"" end="\"" contains=glintSpecial
+syn region glintByte start="`" skip="\\`" end="`" contains=glintSpecial
 
 syn keyword glintFFITypes
   \ cshort
@@ -145,6 +146,7 @@ hi def link glintBuiltinFunc        Identifier
 hi def link glintDataTypes          Structure
 hi def link glintSupplant           StorageClass
 hi def link glintBooleans           Boolean
+hi def link glintByte               Character
 
 let b:current_syntax = 'glint'
 

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -53,6 +53,11 @@ syn keyword glintKeywords
   \ print
   \ in
   \ mapf
+  \ lambda
+  \ has
+  \ apply
+  \ typeof
+  \ template
 
 syn keyword glintRepeat
   \ for

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -25,14 +25,19 @@ syn keyword glintFFITypes
   \ void
 
 syn keyword glintPrimitiveTypes
-  \ Bool
-  \ Boolean
-  \ Byte
+  \ byte
   \ bool
   \ boolean
   \ int
   \ uint
   \ void
+
+if exists("glint_use_uppercase_primitives")
+  syn keyword glintPrimitiveTypes
+    \ Bool
+    \ Boolean
+    \ Byte
+endif
 
 syn keyword glintDataTypes
   \ struct

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -118,6 +118,10 @@ syn keyword glintSupplant supplant
 " NOTE: Include semicolon at the end of line?
 syn match glintModuleName "\<[a-zA-Z0-9_]*" contained skipwhite
 
+syn keyword glintBooleans
+  \ true
+  \ false
+
 hi def link glintFFITypes           Type
 hi def link glintPrimitiveTypes     Type
 hi def link glintKeywords           Keyword
@@ -140,6 +144,7 @@ hi def link glintModuleName         Function
 hi def link glintBuiltinFunc        Identifier
 hi def link glintDataTypes          Structure
 hi def link glintSupplant           StorageClass
+hi def link glintBooleans           Boolean
 
 let b:current_syntax = 'glint'
 

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -43,9 +43,13 @@ syn keyword glintKeywords
   \ return
   \ sizeof
   \ match
+  \ print
+  \ in
+  \ mapf
 
 syn keyword glintRepeat
   \ for
+  \ cfor
   \ while
 
 syn keyword glintConditional
@@ -69,7 +73,26 @@ syn keyword glintFunctionAttributes
 
 syn keyword glintTypeAttributes alignas
 
-syn match glintOperators "?\|+\|-\|\*\|:\|,\|<\|>\|&\||\|!\|\~\|%\|=\|\.\|/\(/\|*\)\@!"
+" syn match glintOperators "?\|+\|-\|\*\|:\|,\|<\|>\|&\||\|!\|\~\|%\|=\|\.\|/\(/\|*\)\@!"
+syn match glintOperators "[/*+-\%~&|^<>]="
+syn keyword glintOperators
+  \ @
+  \ !
+  \ +
+  \ -
+  \ *
+  \ /
+  \ &
+  \ =
+  \ <
+  \ >
+  \ bitand
+  \ bitor
+  \ bitxor
+  \ ::
+  \ :
+  \ ++
+  \ --
 
 syn match glintNumber "\v<\d+>"
 
@@ -107,3 +130,5 @@ hi def link glintDataTypes          Structure
 hi def link glintSupplant           StorageClass
 
 let b:current_syntax = 'glint'
+
+" vim:sw=2 ts=2:

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -102,6 +102,7 @@ syn keyword glintOperators
   \ bitand
   \ bitor
   \ bitxor
+  \ bitnot
   \ ++
   \ --
 

--- a/editor/glint/glint/syntax/glint.vim
+++ b/editor/glint/glint/syntax/glint.vim
@@ -77,6 +77,7 @@ syn keyword glintTypeAttributes alignas
 
 " syn match glintOperators "?\|+\|-\|\*\|:\|,\|<\|>\|&\||\|!\|\~\|%\|=\|\.\|/\(/\|*\)\@!"
 syn match glintOperators "[/*+-\%~&|^<>]="
+syn match glintOperators ":"
 syn keyword glintOperators
   \ @
   \ !
@@ -91,8 +92,6 @@ syn keyword glintOperators
   \ bitand
   \ bitor
   \ bitxor
-  \ ::
-  \ :
   \ ++
   \ --
 


### PR DESCRIPTION
I'm not entirely sure what else to add and would appreciate corrections. So far, I'm only sure about `cfor`, `csize`, and `cusize`.

As far as I understand, `lambda`, `has`, `typeof`, `true`, and `false` aren't used anywhere, but they seem to have implementations (though `lambda` doesn't work for me, but maybe I'm using it incorrectly).